### PR TITLE
Fix CI format-check (clang-format for xmla and pbi_scanner_extension)

### DIFF
--- a/src/pbi_scanner_extension.cpp
+++ b/src/pbi_scanner_extension.cpp
@@ -83,8 +83,7 @@ static void ParseBinXmlFirstTextTestFunction(DataChunk &args,
           throw InvalidInputException(
               "expected exactly one parsed BINXML row with one column");
         }
-        return StringVector::AddString(result,
-                                       parsed.rows[0][0].ToString());
+        return StringVector::AddString(result, parsed.rows[0][0].ToString());
       });
 }
 
@@ -209,10 +208,10 @@ static void LoadInternal(ExtensionLoader &loader) {
       ScalarFunction("__pbi_scanner_test_coerce_xml_text",
                      {LogicalType::VARCHAR, LogicalType::VARCHAR},
                      LogicalType::VARCHAR, CoerceXmlTextTestFunction));
-  loader.RegisterFunction(ScalarFunction(
-      "__pbi_scanner_test_effective_execution_transport",
-      {LogicalType::VARCHAR}, LogicalType::VARCHAR,
-      EffectiveExecutionTransportTestFunction));
+  loader.RegisterFunction(
+      ScalarFunction("__pbi_scanner_test_effective_execution_transport",
+                     {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+                     EffectiveExecutionTransportTestFunction));
 }
 
 void PbiScannerExtension::Load(ExtensionLoader &loader) {

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -1661,8 +1661,9 @@ private:
                           "offset %llu",
                           static_cast<unsigned long long>(substitution_offset));
       }
-      BinXmlParser nested(const_data_ptr_cast(value.binxml.data() + nested_offset),
-                          value.binxml.size() - nested_offset, sink);
+      BinXmlParser nested(
+          const_data_ptr_cast(value.binxml.data() + nested_offset),
+          value.binxml.size() - nested_offset, sink);
       nested.ParseDocument();
       return true;
     }
@@ -1864,8 +1865,9 @@ private:
   void ParseToken(uint8_t token) {
     auto token_offset = offset - 1;
     if (IsSsasRecordFamilyToken(token)) {
-      throw IOException("BINXML encountered SSAS record token 0x%02x at offset %llu",
-                        token, static_cast<unsigned long long>(token_offset));
+      throw IOException(
+          "BINXML encountered SSAS record token 0x%02x at offset %llu", token,
+          static_cast<unsigned long long>(token_offset));
     }
     auto base = BaseToken(token);
     if (base == FRAGMENT_HEADER_TOKEN) {
@@ -2098,7 +2100,8 @@ private:
     uint32_t prefix_id;
     uint32_t local_id;
     if (first > strings.size() + 1) {
-      // Some SSAS streams emit an explicit sparse NameId before URI/Prefix/Local.
+      // Some SSAS streams emit an explicit sparse NameId before
+      // URI/Prefix/Local.
       name_id = first;
       uri_id = ReadVarUInt();
       prefix_id = ReadVarUInt();
@@ -2177,7 +2180,8 @@ private:
       return std::to_string(ReadByte());
     case 0x19: {
       Ensure(2);
-      auto value = static_cast<uint16_t>(data[offset] | (data[offset + 1] << 8));
+      auto value =
+          static_cast<uint16_t>(data[offset] | (data[offset + 1] << 8));
       offset += 2;
       return std::to_string(value);
     }
@@ -2275,21 +2279,22 @@ private:
     case 0x1B:
     case 0x16:
     case 0x17:
-    case EMPTY_TEXT_TOKEN:
-      {
-        auto cell_name = pending_start ? pending_name : last_started_name;
-        FlushPendingStart();
-        auto text = ReadTextValue(token);
-        if (DebugSsasMeasuresEnabled() && !cell_name.empty() &&
-            measure_trace_count < MEASURE_TRACE_LIMIT) {
-          std::fprintf(stderr,
-                       "[pbi_scanner] SSAS row cell=%s token=0x%02x text_len=%llu text=\"%s\"\n",
-                       cell_name.c_str(), static_cast<unsigned int>(token),
-                       static_cast<unsigned long long>(text.size()), text.c_str());
-          measure_trace_count++;
-        }
-        sink.Text(text);
+    case EMPTY_TEXT_TOKEN: {
+      auto cell_name = pending_start ? pending_name : last_started_name;
+      FlushPendingStart();
+      auto text = ReadTextValue(token);
+      if (DebugSsasMeasuresEnabled() && !cell_name.empty() &&
+          measure_trace_count < MEASURE_TRACE_LIMIT) {
+        std::fprintf(stderr,
+                     "[pbi_scanner] SSAS row cell=%s token=0x%02x "
+                     "text_len=%llu text=\"%s\"\n",
+                     cell_name.c_str(), static_cast<unsigned int>(token),
+                     static_cast<unsigned long long>(text.size()),
+                     text.c_str());
+        measure_trace_count++;
       }
+      sink.Text(text);
+    }
       return;
     default:
       FailUnsupported(token, token_offset);
@@ -2405,8 +2410,8 @@ static idx_t SkipOptionalSsasFramingMarker(const std::string &payload,
   return offset;
 }
 
-static std::vector<idx_t> BuildNormalizedPayloadCandidates(
-    const std::string &payload) {
+static std::vector<idx_t>
+BuildNormalizedPayloadCandidates(const std::string &payload) {
   std::vector<idx_t> candidates;
   candidates.push_back(0);
 
@@ -2458,8 +2463,10 @@ static bool IsRecoverableEarlyFramingError(const Exception &ex,
   if (parser_offset >= 8) {
     return false;
   }
-  return message.find("unsupported token 0xdf at offset 0") != std::string::npos ||
-         message.find("unsupported token 0xfe at offset") != std::string::npos ||
+  return message.find("unsupported token 0xdf at offset 0") !=
+             std::string::npos ||
+         message.find("unsupported token 0xfe at offset") !=
+             std::string::npos ||
          message.find("encountered ssas record token") != std::string::npos ||
          message.find("ssas binary xml unsupported token") != std::string::npos;
 }
@@ -2643,7 +2650,8 @@ Value CoerceXmlValueForTesting(const std::string &raw_value,
   return CoerceXmlValue(raw_value, coercion_kind);
 }
 
-std::string EffectiveExecutionTransportForTesting(const std::string &statement) {
+std::string
+EffectiveExecutionTransportForTesting(const std::string &statement) {
   (void)statement;
   auto mode = ResolveXmlaTransportMode();
   switch (mode) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The latest [Main Extension Distribution Pipeline](https://github.com/crazy-treyn/pbi_scanner/actions) run failed in **Code Quality Check → Format Check** with:

`Failed format-check: differences were found in the following files: src/pbi_scanner_extension.cpp, src/xmla.cpp`

This change applies the formatter output from DuckDB’s `format.py` / `.clang-format` to those two files (line breaks, bracing, string literal splits). No behavior changes intended.

## Verification

- `make format-check` passes locally (with the same tool stack as CI: clang-format-11, black, etc.).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96799203-f5e9-44b1-ba66-00348ed46f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96799203-f5e9-44b1-ba66-00348ed46f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

