### PR TITLE
Fix DuckDB main build: include string_vector.hpp where StringVector moved

### DIFF
--- a/src/vector_writer.cpp
+++ b/src/vector_writer.cpp
@@ -2,6 +2,9 @@
 
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/date.hpp"
+#if __has_include("duckdb/common/vector/string_vector.hpp")
+#include "duckdb/common/vector/string_vector.hpp"
+#endif
 #if __has_include("duckdb/common/vector/flat_vector.hpp")
 #include "duckdb/common/vector/flat_vector.hpp"
 #define PBI_SCANNER_HAS_FLAT_VECTOR_GET_DATA_MUTABLE 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI `duckdb-next-build` compiles this extension against DuckDB **main**. A recent DuckDB change split `StringVector` out of `duckdb/common/types/vector.hpp` into `duckdb/common/vector/string_vector.hpp`. `vector_writer.cpp` calls `StringVector::AddString` but did not include the new header, which fails compilation on main with `use of undeclared identifier 'StringVector'`.

## Fix

Conditionally include `duckdb/common/vector/string_vector.hpp` when it exists (`__has_include`). DuckDB **v1.5.2** does not ship that header, so the include is skipped there and behavior is unchanged.

## Verification

- Built `pbi_scanner_loadable_extension` against DuckDB **main** (local submodule checkout): compiles.
- Built the same target against DuckDB **v1.5.2**: compiles.
- Ran `./build/release-v152/test/unittest test/sql/pbi_scanner.test`: all tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10ace718-3c28-49c2-b44b-175d9784456f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10ace718-3c28-49c2-b44b-175d9784456f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

