### PR TITLE
Fix: xmla ssas binxml scalar token parsing

### DIFF
--- a/.cursor/setup-worktree-unix.sh
+++ b/.cursor/setup-worktree-unix.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cursor injects ROOT_WORKTREE_PATH (main checkout) when running worktree setup.
+if [[ -n "${ROOT_WORKTREE_PATH:-}" ]] && [[ -f "${ROOT_WORKTREE_PATH}/.env" ]] && [[ ! -f .env ]]; then
+	cp "${ROOT_WORKTREE_PATH}/.env" .env
+fi
+
+git submodule sync --recursive
+git submodule update --init --recursive
+
+if [[ ! -f extension-ci-tools/makefiles/duckdb_extension.Makefile ]]; then
+	echo "worktree bootstrap failed: extension-ci-tools submodule is missing expected files" >&2
+	echo "Run: git submodule sync --recursive && git submodule update --init --recursive" >&2
+	exit 1
+fi

--- a/.cursor/setup-worktree-windows.ps1
+++ b/.cursor/setup-worktree-windows.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+if ($env:ROOT_WORKTREE_PATH -and (Test-Path (Join-Path $env:ROOT_WORKTREE_PATH '.env')) -and -not (Test-Path '.env')) {
+	Copy-Item (Join-Path $env:ROOT_WORKTREE_PATH '.env') '.env'
+}
+
+git submodule sync --recursive
+git submodule update --init --recursive
+
+if (-not (Test-Path 'extension-ci-tools\makefiles\duckdb_extension.Makefile')) {
+	Write-Error 'worktree bootstrap failed: extension-ci-tools submodule is missing expected files. Run: git submodule sync --recursive; git submodule update --init --recursive'
+}

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,10 @@
+{
+  "setup-worktree-unix": [
+    "if [ -f \"$ROOT_WORKTREE_PATH/.env\" ] && [ ! -f .env ]; then cp \"$ROOT_WORKTREE_PATH/.env\" .env; fi",
+    "git submodule update --init --recursive"
+  ],
+  "setup-worktree-windows": [
+    "if exist \"%ROOT_WORKTREE_PATH%\\.env\" if not exist \".env\" copy \"%ROOT_WORKTREE_PATH%\\.env\" \".env\"",
+    "git submodule update --init --recursive"
+  ]
+}

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,10 +1,4 @@
 {
-  "setup-worktree-unix": [
-    "if [ -f \"$ROOT_WORKTREE_PATH/.env\" ] && [ ! -f .env ]; then cp \"$ROOT_WORKTREE_PATH/.env\" .env; fi",
-    "git submodule update --init --recursive"
-  ],
-  "setup-worktree-windows": [
-    "if exist \"%ROOT_WORKTREE_PATH%\\.env\" if not exist \".env\" copy \"%ROOT_WORKTREE_PATH%\\.env\" \".env\"",
-    "git submodule update --init --recursive"
-  ]
+  "setup-worktree-unix": "setup-worktree-unix.sh",
+  "setup-worktree-windows": "setup-worktree-windows.ps1"
 }

--- a/README.md
+++ b/README.md
@@ -286,7 +286,19 @@ If you use Cursor worktrees (`/worktree` or `--worktree`), this repo includes
 
 - Copy `.env` from the root worktree when present (only if the new worktree
   does not already have one)
-- Run `git submodule update --init --recursive`
+- Run `git submodule sync --recursive` and `git submodule update --init --recursive`
+- Fail fast if `extension-ci-tools` did not populate (so submodule problems are not silent)
+
+Bootstrapping submodules does **not** run `make`; build artifacts such as
+`./build/release/test/unittest` appear only after you build in that worktree
+(for example `make` / `make test`).
+
+If setup did not run (or you need to repair a worktree manually), from the
+worktree root you can run:
+
+```bash
+bash .cursor/setup-worktree-unix.sh
+```
 
 ## Platform Notes
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,15 @@ uv run bench_native_http.py --smoke
 uv run --group bench query_semantic_model_minimal.py
 ```
 
+### Cursor Worktree Setup
+
+If you use Cursor worktrees (`/worktree` or `--worktree`), this repo includes
+`.cursor/worktrees.json` to bootstrap each new worktree automatically:
+
+- Copy `.env` from the root worktree when present (only if the new worktree
+  does not already have one)
+- Run `git submodule update --init --recursive`
+
 ## Platform Notes
 
 ### macOS

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -1222,9 +1222,16 @@ public:
   }
 
 private:
-  // MS-BINXML ValueText (matches BinXmlParser VALUE_TEXT_TOKEN semantics).
-  static constexpr uint8_t BINXML_VALUE_TEXT_TOKEN = 0x05;
-  static constexpr uint8_t BINXML_STRING_VALUE_TYPE = 0x01;
+  static constexpr uint8_t SQL_SMALLINT_TOKEN = 0x01;
+  static constexpr uint8_t SQL_INT_TOKEN = 0x02;
+  static constexpr uint8_t SQL_REAL_TOKEN = 0x03;
+  static constexpr uint8_t SQL_FLOAT_TOKEN = 0x04;
+  static constexpr uint8_t SQL_MONEY_TOKEN = 0x05;
+  static constexpr uint8_t SQL_BIT_TOKEN = 0x06;
+  static constexpr uint8_t SQL_TINYINT_TOKEN = 0x07;
+  static constexpr uint8_t SQL_BIGINT_TOKEN = 0x08;
+  static constexpr uint8_t SQL_NCHAR_TOKEN = 0x0E;
+  static constexpr uint8_t SQL_NVARCHAR_TOKEN = 0x11;
   static constexpr uint8_t EMPTY_TEXT_TOKEN = 0x86;
   static constexpr idx_t MEASURE_TRACE_LIMIT = 200;
 
@@ -1322,9 +1329,18 @@ private:
     return result;
   }
 
+  int32_t ReadInt32() { return static_cast<int32_t>(ReadUInt32()); }
+
   double ReadDouble() {
     auto raw = ReadUInt64();
     double value;
+    std::memcpy(&value, &raw, sizeof(value));
+    return value;
+  }
+
+  float ReadFloat() {
+    auto raw = ReadUInt32();
+    float value;
     std::memcpy(&value, &raw, sizeof(value));
     return value;
   }
@@ -1350,6 +1366,34 @@ private:
   std::string FormatDouble(double value) const {
     std::ostringstream stream;
     stream << std::setprecision(17) << value;
+    return stream.str();
+  }
+
+  std::string FormatScaledInteger(int64_t raw_value, int32_t scale) const {
+    bool negative = raw_value < 0;
+    uint64_t abs_value;
+    if (negative) {
+      abs_value = static_cast<uint64_t>(-(raw_value + 1)) + 1;
+    } else {
+      abs_value = static_cast<uint64_t>(raw_value);
+    }
+    auto integer_part = abs_value / static_cast<uint64_t>(scale);
+    auto fractional_part = abs_value % static_cast<uint64_t>(scale);
+    std::ostringstream stream;
+    if (negative) {
+      stream << "-";
+    }
+    stream << integer_part;
+    if (fractional_part != 0) {
+      std::string fraction = std::to_string(fractional_part);
+      while (fraction.size() < 4) {
+        fraction.insert(fraction.begin(), '0');
+      }
+      while (!fraction.empty() && fraction.back() == '0') {
+        fraction.pop_back();
+      }
+      stream << "." << fraction;
+    }
     return stream.str();
   }
 
@@ -1483,20 +1527,6 @@ private:
     return ReadUtf16String(length, false);
   }
 
-  std::string ReadBinXmlInlineUnicodeValueText() {
-    auto string_type = ReadByte();
-    if (string_type != BINXML_STRING_VALUE_TYPE) {
-      throw IOException(
-          "SSAS binary XML unsupported ValueText type 0x%02x at offset %llu",
-          string_type, static_cast<unsigned long long>(offset - 1));
-    }
-    Ensure(2);
-    auto code_units = static_cast<uint16_t>(data[offset]) |
-                      static_cast<uint16_t>(data[offset + 1] << 8);
-    offset += 2;
-    return ReadUtf16String(code_units, false);
-  }
-
   bool IsLikelyRecordToken(uint8_t token) const {
     switch (token) {
     case 0x00:
@@ -1552,43 +1582,37 @@ private:
     if (payload_end == size) {
       return true;
     }
-    auto next_byte = static_cast<uint8_t>(data[payload_end]);
-    return IsLikelyRecordToken(next_byte) ||
-           next_byte == BINXML_VALUE_TEXT_TOKEN;
+    return IsLikelyRecordToken(static_cast<uint8_t>(data[payload_end]));
   }
 
   std::string ReadTextValue(uint8_t token) {
     switch (token) {
-    case BINXML_VALUE_TEXT_TOKEN:
-      return ReadBinXmlInlineUnicodeValueText();
-    case 0x04:
-      return FormatDouble(ReadDouble());
-    case 0x08:
-      return std::to_string(static_cast<int64_t>(ReadUInt64()));
-    case 0x10:
-    case 0x0E:
-    case 0x11:
-      return ReadInlineUtf16Value();
-    case 0x12:
-      return ReadSqlDateTimeValueText();
-    case 0x13: {
+    case SQL_SMALLINT_TOKEN: {
       Ensure(2);
       auto value = static_cast<int16_t>(data[offset] | (data[offset + 1] << 8));
       offset += 2;
       return std::to_string(value);
     }
-    case 0x14: {
-      Ensure(4);
-      auto value =
-          static_cast<int32_t>(static_cast<uint32_t>(data[offset]) |
-                               (static_cast<uint32_t>(data[offset + 1]) << 8) |
-                               (static_cast<uint32_t>(data[offset + 2]) << 16) |
-                               (static_cast<uint32_t>(data[offset + 3]) << 24));
-      offset += 4;
-      return std::to_string(value);
-    }
-    case 0x15:
+    case SQL_INT_TOKEN:
+      return std::to_string(ReadInt32());
+    case SQL_REAL_TOKEN:
+      return FormatDouble(ReadFloat());
+    case SQL_FLOAT_TOKEN:
       return FormatDouble(ReadDouble());
+    case SQL_MONEY_TOKEN:
+      return FormatScaledInteger(static_cast<int64_t>(ReadUInt64()), 10000);
+    case SQL_BIT_TOKEN:
+      return ReadByte() ? "true" : "false";
+    case SQL_TINYINT_TOKEN:
+      return std::to_string(ReadByte());
+    case SQL_BIGINT_TOKEN:
+      return std::to_string(static_cast<int64_t>(ReadUInt64()));
+    case 0x10:
+    case SQL_NCHAR_TOKEN:
+    case SQL_NVARCHAR_TOKEN:
+      return ReadInlineUtf16Value();
+    case 0x12:
+      return ReadSqlDateTimeValueText();
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -1618,10 +1642,6 @@ private:
     }
     case 0x1B:
       return std::to_string(ReadUInt64());
-    case 0x16:
-      return "true";
-    case 0x17:
-      return "false";
     case EMPTY_TEXT_TOKEN:
       return std::string();
     default:
@@ -1674,6 +1694,24 @@ private:
           return;
         }
       }
+      if (pending_start || !last_started_name.empty()) {
+        auto cell_name = pending_start ? pending_name : last_started_name;
+        FlushPendingStart();
+        auto text = ReadTextValue(SQL_SMALLINT_TOKEN);
+        if (DebugSsasMeasuresEnabled() && !cell_name.empty() &&
+            measure_trace_count < MEASURE_TRACE_LIMIT) {
+          std::fprintf(stderr,
+                       "[pbi_scanner] SSAS row cell=%s token=0x%02x "
+                       "text_len=%llu text=\"%s\"\n",
+                       cell_name.c_str(),
+                       static_cast<unsigned int>(SQL_SMALLINT_TOKEN),
+                       static_cast<unsigned long long>(text.size()),
+                       text.c_str());
+          measure_trace_count++;
+        }
+        sink.Text(text);
+        return;
+      }
       FlushPendingStart();
       return;
     case 0xF6:
@@ -1686,15 +1724,17 @@ private:
       FlushPendingStart();
       sink.EndElement();
       return;
-    case 0x04:
-    case 0x08:
+    case SQL_INT_TOKEN:
+    case SQL_REAL_TOKEN:
+    case SQL_FLOAT_TOKEN:
+    case SQL_MONEY_TOKEN:
+    case SQL_BIT_TOKEN:
+    case SQL_TINYINT_TOKEN:
+    case SQL_BIGINT_TOKEN:
     case 0x10:
-    case 0x0E:
-    case 0x11:
+    case SQL_NCHAR_TOKEN:
+    case SQL_NVARCHAR_TOKEN:
     case 0x12:
-    case 0x13:
-    case 0x14:
-    case 0x15:
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -1703,9 +1743,6 @@ private:
     case 0x19:
     case 0x1A:
     case 0x1B:
-    case 0x16:
-    case 0x17:
-    case BINXML_VALUE_TEXT_TOKEN:
     case EMPTY_TEXT_TOKEN: {
       auto cell_name = pending_start ? pending_name : last_started_name;
       FlushPendingStart();
@@ -1785,8 +1822,16 @@ private:
   class NeedMoreInputException {};
 
   enum class ElementKind : uint8_t { OTHER, SCHEMA, ROW };
-  static constexpr uint8_t BINXML_VALUE_TEXT_TOKEN = 0x05;
-  static constexpr uint8_t BINXML_STRING_VALUE_TYPE = 0x01;
+  static constexpr uint8_t SQL_SMALLINT_TOKEN = 0x01;
+  static constexpr uint8_t SQL_INT_TOKEN = 0x02;
+  static constexpr uint8_t SQL_REAL_TOKEN = 0x03;
+  static constexpr uint8_t SQL_FLOAT_TOKEN = 0x04;
+  static constexpr uint8_t SQL_MONEY_TOKEN = 0x05;
+  static constexpr uint8_t SQL_BIT_TOKEN = 0x06;
+  static constexpr uint8_t SQL_TINYINT_TOKEN = 0x07;
+  static constexpr uint8_t SQL_BIGINT_TOKEN = 0x08;
+  static constexpr uint8_t SQL_NCHAR_TOKEN = 0x0E;
+  static constexpr uint8_t SQL_NVARCHAR_TOKEN = 0x11;
   static constexpr uint8_t EMPTY_TEXT_TOKEN = 0x86;
   static constexpr idx_t CELL_TRACE_LIMIT = 80;
   static constexpr idx_t STREAMING_CHECKPOINT_THRESHOLD = 512;
@@ -2016,6 +2061,8 @@ private:
     return value;
   }
 
+  int32_t ReadInt32() { return static_cast<int32_t>(ReadUInt32()); }
+
   uint64_t ReadUInt64() {
     Ensure(8);
     uint64_t result = 0;
@@ -2029,6 +2076,13 @@ private:
   double ReadDouble() {
     auto raw = ReadUInt64();
     double value;
+    std::memcpy(&value, &raw, sizeof(value));
+    return value;
+  }
+
+  float ReadFloat() {
+    auto raw = ReadUInt32();
+    float value;
     std::memcpy(&value, &raw, sizeof(value));
     return value;
   }
@@ -2054,6 +2108,34 @@ private:
   std::string FormatDouble(double value) const {
     std::ostringstream stream;
     stream << std::setprecision(17) << value;
+    return stream.str();
+  }
+
+  std::string FormatScaledInteger(int64_t raw_value, int32_t scale) const {
+    bool negative = raw_value < 0;
+    uint64_t abs_value;
+    if (negative) {
+      abs_value = static_cast<uint64_t>(-(raw_value + 1)) + 1;
+    } else {
+      abs_value = static_cast<uint64_t>(raw_value);
+    }
+    auto integer_part = abs_value / static_cast<uint64_t>(scale);
+    auto fractional_part = abs_value % static_cast<uint64_t>(scale);
+    std::ostringstream stream;
+    if (negative) {
+      stream << "-";
+    }
+    stream << integer_part;
+    if (fractional_part != 0) {
+      std::string fraction = std::to_string(fractional_part);
+      while (fraction.size() < 4) {
+        fraction.insert(fraction.begin(), '0');
+      }
+      while (!fraction.empty() && fraction.back() == '0') {
+        fraction.pop_back();
+      }
+      stream << "." << fraction;
+    }
     return stream.str();
   }
 
@@ -2282,21 +2364,6 @@ private:
     return ReadUtf16String(length, false);
   }
 
-  std::string ReadBinXmlInlineUnicodeValueText() {
-    auto string_type = ReadByte();
-    if (string_type != BINXML_STRING_VALUE_TYPE) {
-      throw IOException(
-          "SSAS fast row parser unsupported ValueText type 0x%02x at offset "
-          "%llu",
-          string_type, static_cast<unsigned long long>(offset - 1));
-    }
-    Ensure(2);
-    auto code_units = static_cast<uint16_t>(data[offset]) |
-                      static_cast<uint16_t>(data[offset + 1] << 8);
-    offset += 2;
-    return ReadUtf16String(code_units, false);
-  }
-
   bool IsLikelyRecordToken(uint8_t token) const {
     switch (token) {
     case 0x00:
@@ -2352,31 +2419,33 @@ private:
     if (payload_end == size) {
       return true;
     }
-    auto next_byte = static_cast<uint8_t>(data[payload_end]);
-    return IsLikelyRecordToken(next_byte) ||
-           next_byte == BINXML_VALUE_TEXT_TOKEN;
+    return IsLikelyRecordToken(static_cast<uint8_t>(data[payload_end]));
   }
 
   std::string ReadTextValue(uint8_t token) {
     switch (token) {
-    case BINXML_VALUE_TEXT_TOKEN:
-      return ReadBinXmlInlineUnicodeValueText();
-    case 0x04:
+    case SQL_SMALLINT_TOKEN:
+      return std::to_string(static_cast<int16_t>(ReadUInt16()));
+    case SQL_INT_TOKEN:
+      return std::to_string(ReadInt32());
+    case SQL_REAL_TOKEN:
+      return FormatDouble(ReadFloat());
+    case SQL_FLOAT_TOKEN:
       return FormatDouble(ReadDouble());
-    case 0x08:
+    case SQL_MONEY_TOKEN:
+      return FormatScaledInteger(static_cast<int64_t>(ReadUInt64()), 10000);
+    case SQL_BIT_TOKEN:
+      return ReadByte() ? "true" : "false";
+    case SQL_TINYINT_TOKEN:
+      return std::to_string(ReadByte());
+    case SQL_BIGINT_TOKEN:
       return std::to_string(static_cast<int64_t>(ReadUInt64()));
     case 0x10:
-    case 0x0E:
-    case 0x11:
+    case SQL_NCHAR_TOKEN:
+    case SQL_NVARCHAR_TOKEN:
       return ReadInlineUtf16Value();
     case 0x12:
       return ReadSqlDateTimeValueText();
-    case 0x13:
-      return std::to_string(static_cast<int16_t>(ReadUInt16()));
-    case 0x14:
-      return std::to_string(static_cast<int32_t>(ReadUInt32()));
-    case 0x15:
-      return FormatDouble(ReadDouble());
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -2394,10 +2463,6 @@ private:
       return std::to_string(ReadUInt32());
     case 0x1B:
       return std::to_string(ReadUInt64());
-    case 0x16:
-      return "true";
-    case 0x17:
-      return "false";
     case EMPTY_TEXT_TOKEN:
       return std::string();
     default:
@@ -2412,12 +2477,10 @@ private:
 
   Value ReadCellValue(uint8_t token, XmlaCoercionKind coercion_kind) {
     switch (token) {
-    case BINXML_VALUE_TEXT_TOKEN:
-      return ValueFromText(ReadBinXmlInlineUnicodeValueText(),
-                           coercion_kind);
-    case 0x04:
-    case 0x15: {
-      auto value = ReadDouble();
+    case SQL_REAL_TOKEN:
+    case SQL_FLOAT_TOKEN: {
+      auto value = token == SQL_REAL_TOKEN ? static_cast<double>(ReadFloat())
+                                           : ReadDouble();
       if (coercion_kind == XmlaCoercionKind::DOUBLE ||
           coercion_kind == XmlaCoercionKind::INFER) {
         return Value::DOUBLE(value);
@@ -2438,7 +2501,11 @@ private:
       }
       return ValueFromText(FormatDouble(numeric_value), coercion_kind);
     }
-    case 0x08: {
+    case SQL_MONEY_TOKEN: {
+      auto text = FormatScaledInteger(static_cast<int64_t>(ReadUInt64()), 10000);
+      return ValueFromText(text, coercion_kind);
+    }
+    case SQL_BIGINT_TOKEN: {
       auto value = static_cast<int64_t>(ReadUInt64());
       if (coercion_kind == XmlaCoercionKind::BIGINT ||
           coercion_kind == XmlaCoercionKind::INFER) {
@@ -2453,7 +2520,7 @@ private:
       auto text = ReadSqlDateTimeValueText();
       return ValueFromText(text, coercion_kind);
     }
-    case 0x13: {
+    case SQL_SMALLINT_TOKEN: {
       auto value = static_cast<int16_t>(ReadUInt16());
       if (coercion_kind == XmlaCoercionKind::BIGINT ||
           coercion_kind == XmlaCoercionKind::INFER) {
@@ -2464,8 +2531,8 @@ private:
       }
       return ValueFromText(std::to_string(value), coercion_kind);
     }
-    case 0x14: {
-      auto value = static_cast<int32_t>(ReadUInt32());
+    case SQL_INT_TOKEN: {
+      auto value = ReadInt32();
       if (coercion_kind == XmlaCoercionKind::BIGINT ||
           coercion_kind == XmlaCoercionKind::INFER) {
         return Value::BIGINT(value);
@@ -2475,7 +2542,7 @@ private:
       }
       return ValueFromText(std::to_string(value), coercion_kind);
     }
-    case 0x18: {
+    case SQL_TINYINT_TOKEN: {
       auto value = static_cast<uint64_t>(ReadByte());
       if (coercion_kind == XmlaCoercionKind::UBIGINT) {
         return Value::UBIGINT(value);
@@ -2489,6 +2556,19 @@ private:
       }
       return ValueFromText(std::to_string(value), coercion_kind);
     }
+    case SQL_BIT_TOKEN:
+      if (ReadByte()) {
+        if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
+            coercion_kind == XmlaCoercionKind::INFER) {
+          return Value::BOOLEAN(true);
+        }
+        return ValueFromText("true", coercion_kind);
+      }
+      if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
+          coercion_kind == XmlaCoercionKind::INFER) {
+        return Value::BOOLEAN(false);
+      }
+      return ValueFromText("false", coercion_kind);
     case 0x19: {
       auto value = static_cast<uint64_t>(ReadUInt16());
       if (coercion_kind == XmlaCoercionKind::UBIGINT) {
@@ -2528,21 +2608,9 @@ private:
       }
       return ValueFromText(std::to_string(value), coercion_kind);
     }
-    case 0x16:
-      if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
-          coercion_kind == XmlaCoercionKind::INFER) {
-        return Value::BOOLEAN(true);
-      }
-      return ValueFromText("true", coercion_kind);
-    case 0x17:
-      if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
-          coercion_kind == XmlaCoercionKind::INFER) {
-        return Value::BOOLEAN(false);
-      }
-      return ValueFromText("false", coercion_kind);
     case 0x10:
-    case 0x0E:
-    case 0x11:
+    case SQL_NCHAR_TOKEN:
+    case SQL_NVARCHAR_TOKEN:
       return ValueFromText(ReadInlineUtf16Value(), coercion_kind);
     case EMPTY_TEXT_TOKEN:
       return ValueFromText(std::string(), coercion_kind);
@@ -2637,6 +2705,10 @@ private:
         ParseStartElement();
         return;
       }
+      if (pending_start || ActiveColumnIndex() != DConstants::INVALID_INDEX) {
+        ParseText(SQL_SMALLINT_TOKEN);
+        return;
+      }
       FlushPendingStart();
       return;
     }
@@ -2649,15 +2721,17 @@ private:
     case 0xF7:
       EndElement();
       return;
-    case 0x04:
-    case 0x08:
+    case SQL_INT_TOKEN:
+    case SQL_REAL_TOKEN:
+    case SQL_FLOAT_TOKEN:
+    case SQL_MONEY_TOKEN:
+    case SQL_BIT_TOKEN:
+    case SQL_TINYINT_TOKEN:
+    case SQL_BIGINT_TOKEN:
     case 0x10:
-    case 0x0E:
-    case 0x11:
+    case SQL_NCHAR_TOKEN:
+    case SQL_NVARCHAR_TOKEN:
     case 0x12:
-    case 0x13:
-    case 0x14:
-    case 0x15:
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -2666,9 +2740,6 @@ private:
     case 0x19:
     case 0x1A:
     case 0x1B:
-    case 0x16:
-    case 0x17:
-    case BINXML_VALUE_TEXT_TOKEN:
     case EMPTY_TEXT_TOKEN:
       ParseText(token);
       return;

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -1694,7 +1694,11 @@ private:
           return;
         }
       }
-      if (pending_start || !last_started_name.empty()) {
+      // 0x01 is ambiguous: SSAS uses it as a compact start/control marker and
+      // MS-BINXML uses it for SQL-SMALLINT. Only consume it as a scalar when it
+      // immediately follows a pending cell start; otherwise keep the historical
+      // control-marker behavior.
+      if (pending_start) {
         auto cell_name = pending_start ? pending_name : last_started_name;
         FlushPendingStart();
         auto text = ReadTextValue(SQL_SMALLINT_TOKEN);
@@ -2417,6 +2421,9 @@ private:
       return false;
     }
     if (payload_end == size) {
+      if (streaming) {
+        throw NeedMoreInputException();
+      }
       return true;
     }
     return IsLikelyRecordToken(static_cast<uint8_t>(data[payload_end]));
@@ -2705,7 +2712,11 @@ private:
         ParseStartElement();
         return;
       }
-      if (pending_start || ActiveColumnIndex() != DConstants::INVALID_INDEX) {
+      // 0x01 is ambiguous: SSAS uses it as a compact start/control marker and
+      // MS-BINXML uses it for SQL-SMALLINT. Only consume it as a scalar when it
+      // immediately follows a pending cell start; otherwise keep the historical
+      // control-marker behavior.
+      if (pending_start) {
         ParseText(SQL_SMALLINT_TOKEN);
         return;
       }

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -1516,7 +1516,9 @@ private:
     if (!pending_start) {
       return;
     }
+    std::string pushed_local = pending_name;
     sink.StartElement(std::move(pending_name), std::move(pending_attributes));
+    element_stack.push_back(std::move(pushed_local));
     pending_attributes.clear();
     pending_name.clear();
     pending_start = false;
@@ -1699,10 +1701,12 @@ private:
     case 0x01:
       // MS-BINXML uses 0x01 for SQL-SMALLINT. SSAS also uses 0x01 as a compact
       // start/control marker; the following varuint can match a known name id.
-      // When we are in a pending cell, the next bytes are always cell payload —
-      // treat as smallint first so low values (e.g. int16 1 = 0x01 0x00) cannot
-      // be mistaken for name id 1.
-      if (pending_start) {
+      // When we are in a pending cell under a data row, the next bytes are cell
+      // payload — treat as smallint first so low values (e.g. int16 1 = 0x01 0x00)
+      // cannot be mistaken for name id 1. Do not do this for arbitrary pending
+      // starts (schema/metadata or a pending row before it is flushed).
+      if (pending_start && !element_stack.empty() &&
+          element_stack.back() == "row") {
         auto cell_name = pending_start ? pending_name : last_started_name;
         FlushPendingStart();
         auto text = ReadTextValue(SQL_SMALLINT_TOKEN);
@@ -1742,6 +1746,9 @@ private:
     case 0xF7:
       FlushPendingStart();
       sink.EndElement();
+      if (!element_stack.empty()) {
+        element_stack.pop_back();
+      }
       return;
     case SQL_INT_TOKEN:
     case SQL_REAL_TOKEN:
@@ -1801,6 +1808,7 @@ private:
   std::string pending_name;
   std::string last_started_name;
   case_insensitive_map_t<std::string> pending_attributes;
+  std::vector<std::string> element_stack;
 };
 
 class SsasFastRowParser {
@@ -2751,7 +2759,7 @@ private:
       ParseStartElement();
       return;
     case 0x01: {
-      if (pending_start) {
+      if (pending_start && ParentIsRow()) {
         ParseText(SQL_SMALLINT_TOKEN);
         return;
       }

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -1222,6 +1222,9 @@ public:
   }
 
 private:
+  // MS-BINXML ValueText (matches BinXmlParser VALUE_TEXT_TOKEN semantics).
+  static constexpr uint8_t BINXML_VALUE_TEXT_TOKEN = 0x05;
+  static constexpr uint8_t BINXML_STRING_VALUE_TYPE = 0x01;
   static constexpr uint8_t EMPTY_TEXT_TOKEN = 0x86;
   static constexpr idx_t MEASURE_TRACE_LIMIT = 200;
 
@@ -1480,6 +1483,20 @@ private:
     return ReadUtf16String(length, false);
   }
 
+  std::string ReadBinXmlInlineUnicodeValueText() {
+    auto string_type = ReadByte();
+    if (string_type != BINXML_STRING_VALUE_TYPE) {
+      throw IOException(
+          "SSAS binary XML unsupported ValueText type 0x%02x at offset %llu",
+          string_type, static_cast<unsigned long long>(offset - 1));
+    }
+    Ensure(2);
+    auto code_units = static_cast<uint16_t>(data[offset]) |
+                      static_cast<uint16_t>(data[offset + 1] << 8);
+    offset += 2;
+    return ReadUtf16String(code_units, false);
+  }
+
   bool IsLikelyRecordToken(uint8_t token) const {
     switch (token) {
     case 0x00:
@@ -1535,11 +1552,15 @@ private:
     if (payload_end == size) {
       return true;
     }
-    return IsLikelyRecordToken(static_cast<uint8_t>(data[payload_end]));
+    auto next_byte = static_cast<uint8_t>(data[payload_end]);
+    return IsLikelyRecordToken(next_byte) ||
+           next_byte == BINXML_VALUE_TEXT_TOKEN;
   }
 
   std::string ReadTextValue(uint8_t token) {
     switch (token) {
+    case BINXML_VALUE_TEXT_TOKEN:
+      return ReadBinXmlInlineUnicodeValueText();
     case 0x04:
       return FormatDouble(ReadDouble());
     case 0x08:
@@ -1684,6 +1705,7 @@ private:
     case 0x1B:
     case 0x16:
     case 0x17:
+    case BINXML_VALUE_TEXT_TOKEN:
     case EMPTY_TEXT_TOKEN: {
       auto cell_name = pending_start ? pending_name : last_started_name;
       FlushPendingStart();
@@ -1763,6 +1785,8 @@ private:
   class NeedMoreInputException {};
 
   enum class ElementKind : uint8_t { OTHER, SCHEMA, ROW };
+  static constexpr uint8_t BINXML_VALUE_TEXT_TOKEN = 0x05;
+  static constexpr uint8_t BINXML_STRING_VALUE_TYPE = 0x01;
   static constexpr uint8_t EMPTY_TEXT_TOKEN = 0x86;
   static constexpr idx_t CELL_TRACE_LIMIT = 80;
   static constexpr idx_t STREAMING_CHECKPOINT_THRESHOLD = 512;
@@ -2258,6 +2282,21 @@ private:
     return ReadUtf16String(length, false);
   }
 
+  std::string ReadBinXmlInlineUnicodeValueText() {
+    auto string_type = ReadByte();
+    if (string_type != BINXML_STRING_VALUE_TYPE) {
+      throw IOException(
+          "SSAS fast row parser unsupported ValueText type 0x%02x at offset "
+          "%llu",
+          string_type, static_cast<unsigned long long>(offset - 1));
+    }
+    Ensure(2);
+    auto code_units = static_cast<uint16_t>(data[offset]) |
+                      static_cast<uint16_t>(data[offset + 1] << 8);
+    offset += 2;
+    return ReadUtf16String(code_units, false);
+  }
+
   bool IsLikelyRecordToken(uint8_t token) const {
     switch (token) {
     case 0x00:
@@ -2313,11 +2352,15 @@ private:
     if (payload_end == size) {
       return true;
     }
-    return IsLikelyRecordToken(static_cast<uint8_t>(data[payload_end]));
+    auto next_byte = static_cast<uint8_t>(data[payload_end]);
+    return IsLikelyRecordToken(next_byte) ||
+           next_byte == BINXML_VALUE_TEXT_TOKEN;
   }
 
   std::string ReadTextValue(uint8_t token) {
     switch (token) {
+    case BINXML_VALUE_TEXT_TOKEN:
+      return ReadBinXmlInlineUnicodeValueText();
     case 0x04:
       return FormatDouble(ReadDouble());
     case 0x08:
@@ -2369,6 +2412,9 @@ private:
 
   Value ReadCellValue(uint8_t token, XmlaCoercionKind coercion_kind) {
     switch (token) {
+    case BINXML_VALUE_TEXT_TOKEN:
+      return ValueFromText(ReadBinXmlInlineUnicodeValueText(),
+                           coercion_kind);
     case 0x04:
     case 0x15: {
       auto value = ReadDouble();
@@ -2622,6 +2668,7 @@ private:
     case 0x1B:
     case 0x16:
     case 0x17:
+    case BINXML_VALUE_TEXT_TOKEN:
     case EMPTY_TEXT_TOKEN:
       ParseText(token);
       return;

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -1613,6 +1613,22 @@ private:
       return ReadInlineUtf16Value();
     case 0x12:
       return ReadSqlDateTimeValueText();
+    // Legacy SSAS compact scalars (same wire shapes; opcode overlap with other
+    // MS-BINXML type tags in non-cell contexts).
+    case 0x13: {
+      Ensure(2);
+      auto value = static_cast<int16_t>(data[offset] | (data[offset + 1] << 8));
+      offset += 2;
+      return std::to_string(value);
+    }
+    case 0x14:
+      return std::to_string(ReadInt32());
+    case 0x15:
+      return FormatDouble(ReadDouble());
+    case 0x16:
+      return "true";
+    case 0x17:
+      return "false";
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -1681,23 +1697,11 @@ private:
       ParseStartElement();
       return;
     case 0x01:
-      // 0x01 can appear both as a compact start-element token and as a control
-      // marker in some strict SX metadata payloads. Disambiguate by probing the
-      // following varuint as a valid known name id.
-      {
-        uint32_t maybe_name_id = 0;
-        idx_t next_offset = offset;
-        if (TryReadVarUIntAt(data, size, offset, maybe_name_id, next_offset) &&
-            (names_by_id.find(maybe_name_id) != names_by_id.end() ||
-             (maybe_name_id >= 1 && maybe_name_id <= names.size()))) {
-          ParseStartElement();
-          return;
-        }
-      }
-      // 0x01 is ambiguous: SSAS uses it as a compact start/control marker and
-      // MS-BINXML uses it for SQL-SMALLINT. Only consume it as a scalar when it
-      // immediately follows a pending cell start; otherwise keep the historical
-      // control-marker behavior.
+      // MS-BINXML uses 0x01 for SQL-SMALLINT. SSAS also uses 0x01 as a compact
+      // start/control marker; the following varuint can match a known name id.
+      // When we are in a pending cell, the next bytes are always cell payload —
+      // treat as smallint first so low values (e.g. int16 1 = 0x01 0x00) cannot
+      // be mistaken for name id 1.
       if (pending_start) {
         auto cell_name = pending_start ? pending_name : last_started_name;
         FlushPendingStart();
@@ -1715,6 +1719,17 @@ private:
         }
         sink.Text(text);
         return;
+      }
+      // Disambiguate compact start vs metadata by probing the following varuint.
+      {
+        uint32_t maybe_name_id = 0;
+        idx_t next_offset = offset;
+        if (TryReadVarUIntAt(data, size, offset, maybe_name_id, next_offset) &&
+            (names_by_id.find(maybe_name_id) != names_by_id.end() ||
+             (maybe_name_id >= 1 && maybe_name_id <= names.size()))) {
+          ParseStartElement();
+          return;
+        }
       }
       FlushPendingStart();
       return;
@@ -1739,6 +1754,11 @@ private:
     case SQL_NCHAR_TOKEN:
     case SQL_NVARCHAR_TOKEN:
     case 0x12:
+    case 0x13:
+    case 0x14:
+    case 0x15:
+    case 0x16:
+    case 0x17:
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -1916,6 +1936,7 @@ private:
   }
 
   void ParseAvailable(bool final) {
+    final_parse_pass = final;
     if (!normalized_preamble && (PeekByte() == 0xDF || PeekByte() == 0xB0)) {
       auto state = streaming ? CaptureState() : ParserState();
       try {
@@ -2421,7 +2442,7 @@ private:
       return false;
     }
     if (payload_end == size) {
-      if (streaming) {
+      if (streaming && !final_parse_pass) {
         throw NeedMoreInputException();
       }
       return true;
@@ -2453,6 +2474,18 @@ private:
       return ReadInlineUtf16Value();
     case 0x12:
       return ReadSqlDateTimeValueText();
+    // Legacy SSAS compact scalars (same wire shapes; opcode overlap with other
+    // MS-BINXML type tags in non-cell contexts).
+    case 0x13:
+      return std::to_string(static_cast<int16_t>(ReadUInt16()));
+    case 0x14:
+      return std::to_string(ReadInt32());
+    case 0x15:
+      return FormatDouble(ReadDouble());
+    case 0x16:
+      return "true";
+    case 0x17:
+      return "false";
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -2494,6 +2527,14 @@ private:
       }
       return ValueFromText(FormatDouble(value), coercion_kind);
     }
+    case 0x15: {
+      auto value = ReadDouble();
+      if (coercion_kind == XmlaCoercionKind::DOUBLE ||
+          coercion_kind == XmlaCoercionKind::INFER) {
+        return Value::DOUBLE(value);
+      }
+      return ValueFromText(FormatDouble(value), coercion_kind);
+    }
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -2527,7 +2568,8 @@ private:
       auto text = ReadSqlDateTimeValueText();
       return ValueFromText(text, coercion_kind);
     }
-    case SQL_SMALLINT_TOKEN: {
+    case SQL_SMALLINT_TOKEN:
+    case 0x13: {
       auto value = static_cast<int16_t>(ReadUInt16());
       if (coercion_kind == XmlaCoercionKind::BIGINT ||
           coercion_kind == XmlaCoercionKind::INFER) {
@@ -2538,7 +2580,8 @@ private:
       }
       return ValueFromText(std::to_string(value), coercion_kind);
     }
-    case SQL_INT_TOKEN: {
+    case SQL_INT_TOKEN:
+    case 0x14: {
       auto value = ReadInt32();
       if (coercion_kind == XmlaCoercionKind::BIGINT ||
           coercion_kind == XmlaCoercionKind::INFER) {
@@ -2571,6 +2614,18 @@ private:
         }
         return ValueFromText("true", coercion_kind);
       }
+      if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
+          coercion_kind == XmlaCoercionKind::INFER) {
+        return Value::BOOLEAN(false);
+      }
+      return ValueFromText("false", coercion_kind);
+    case 0x16:
+      if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
+          coercion_kind == XmlaCoercionKind::INFER) {
+        return Value::BOOLEAN(true);
+      }
+      return ValueFromText("true", coercion_kind);
+    case 0x17:
       if (coercion_kind == XmlaCoercionKind::BOOLEAN ||
           coercion_kind == XmlaCoercionKind::INFER) {
         return Value::BOOLEAN(false);
@@ -2696,6 +2751,10 @@ private:
       ParseStartElement();
       return;
     case 0x01: {
+      if (pending_start) {
+        ParseText(SQL_SMALLINT_TOKEN);
+        return;
+      }
       uint32_t maybe_name_id = 0;
       idx_t next_offset = offset;
       auto has_name_id =
@@ -2710,14 +2769,6 @@ private:
       if (names_by_id.find(maybe_name_id) != names_by_id.end() ||
           (maybe_name_id >= 1 && maybe_name_id <= names.size())) {
         ParseStartElement();
-        return;
-      }
-      // 0x01 is ambiguous: SSAS uses it as a compact start/control marker and
-      // MS-BINXML uses it for SQL-SMALLINT. Only consume it as a scalar when it
-      // immediately follows a pending cell start; otherwise keep the historical
-      // control-marker behavior.
-      if (pending_start) {
-        ParseText(SQL_SMALLINT_TOKEN);
         return;
       }
       FlushPendingStart();
@@ -2743,6 +2794,11 @@ private:
     case SQL_NCHAR_TOKEN:
     case SQL_NVARCHAR_TOKEN:
     case 0x12:
+    case 0x13:
+    case 0x14:
+    case 0x15:
+    case 0x16:
+    case 0x17:
     case 0xAE:
     case 0xAF:
     case 0xB0:
@@ -2783,6 +2839,7 @@ private:
   bool normalized_preamble = false;
   bool debug_trace_enabled = false;
   bool streaming = false;
+  bool final_parse_pass = false;
   std::string owned_data;
 };
 

--- a/src/xmla.cpp
+++ b/src/xmla.cpp
@@ -12,8 +12,8 @@
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 
-#include <chrono>
 #include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <cstdio>
 #include <cstring>
@@ -1702,9 +1702,9 @@ private:
       // MS-BINXML uses 0x01 for SQL-SMALLINT. SSAS also uses 0x01 as a compact
       // start/control marker; the following varuint can match a known name id.
       // When we are in a pending cell under a data row, the next bytes are cell
-      // payload — treat as smallint first so low values (e.g. int16 1 = 0x01 0x00)
-      // cannot be mistaken for name id 1. Do not do this for arbitrary pending
-      // starts (schema/metadata or a pending row before it is flushed).
+      // payload — treat as smallint first so low values (e.g. int16 1 = 0x01
+      // 0x00) cannot be mistaken for name id 1. Do not do this for arbitrary
+      // pending starts (schema/metadata or a pending row before it is flushed).
       if (pending_start && !element_stack.empty() &&
           element_stack.back() == "row") {
         auto cell_name = pending_start ? pending_name : last_started_name;
@@ -1712,19 +1712,19 @@ private:
         auto text = ReadTextValue(SQL_SMALLINT_TOKEN);
         if (DebugSsasMeasuresEnabled() && !cell_name.empty() &&
             measure_trace_count < MEASURE_TRACE_LIMIT) {
-          std::fprintf(stderr,
-                       "[pbi_scanner] SSAS row cell=%s token=0x%02x "
-                       "text_len=%llu text=\"%s\"\n",
-                       cell_name.c_str(),
-                       static_cast<unsigned int>(SQL_SMALLINT_TOKEN),
-                       static_cast<unsigned long long>(text.size()),
-                       text.c_str());
+          std::fprintf(
+              stderr,
+              "[pbi_scanner] SSAS row cell=%s token=0x%02x "
+              "text_len=%llu text=\"%s\"\n",
+              cell_name.c_str(), static_cast<unsigned int>(SQL_SMALLINT_TOKEN),
+              static_cast<unsigned long long>(text.size()), text.c_str());
           measure_trace_count++;
         }
         sink.Text(text);
         return;
       }
-      // Disambiguate compact start vs metadata by probing the following varuint.
+      // Disambiguate compact start vs metadata by probing the following
+      // varuint.
       {
         uint32_t maybe_name_id = 0;
         idx_t next_offset = offset;
@@ -2558,7 +2558,8 @@ private:
       return ValueFromText(FormatDouble(numeric_value), coercion_kind);
     }
     case SQL_MONEY_TOKEN: {
-      auto text = FormatScaledInteger(static_cast<int64_t>(ReadUInt64()), 10000);
+      auto text =
+          FormatScaledInteger(static_cast<int64_t>(ReadUInt64()), 10000);
       return ValueFromText(text, coercion_kind);
     }
     case SQL_BIGINT_TOKEN: {

--- a/test/sql/pbi_scanner.test
+++ b/test/sql/pbi_scanner.test
@@ -70,6 +70,30 @@ SELECT __pbi_scanner_test_parse_streaming_sx_double(
 ----
 112.5
 
+# MS-BINXML ValueText (token 0x05) for a numeric string — SSAS / sx can emit this
+# instead of a binary double; must parse like other text cell values.
+query I
+SELECT __pbi_scanner_test_parse_binxml_double(
+    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f803050105003100310032002e003500f7f7f7'
+);
+----
+112.5
+
+query I
+SELECT __pbi_scanner_test_parse_streaming_sx_double(
+    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f803050105003100310032002e003500f7f7f7',
+    3
+);
+----
+112.5
+
+query T
+SELECT __pbi_scanner_test_parse_binxml_first_text(
+    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f803050105003100310032002e003500f7f7f7'
+);
+----
+112.5
+
 query I
 SELECT CAST(__pbi_scanner_test_metadata_cache_roundtrip() AS INTEGER);
 ----

--- a/test/sql/pbi_scanner.test
+++ b/test/sql/pbi_scanner.test
@@ -70,18 +70,18 @@ SELECT __pbi_scanner_test_parse_streaming_sx_double(
 ----
 112.5
 
-# MS-BINXML ValueText (token 0x05) for a numeric string — SSAS / sx can emit this
-# instead of a binary double; must parse like other text cell values.
+# MS-BINXML SQL-MONEY (token 0x05) — SSAS / sx can emit scalar typed values
+# from the BINXML grammar, not only the compact tokens observed in early tests.
 query I
 SELECT __pbi_scanner_test_parse_binxml_double(
-    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f803050105003100310032002e003500f7f7f7'
+    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f80305882a110000000000f7f7f7'
 );
 ----
 112.5
 
 query I
 SELECT __pbi_scanner_test_parse_streaming_sx_double(
-    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f803050105003100310032002e003500f7f7f7',
+    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f80305882a110000000000f7f7f7',
     3
 );
 ----
@@ -89,7 +89,7 @@ SELECT __pbi_scanner_test_parse_streaming_sx_double(
 
 query T
 SELECT __pbi_scanner_test_parse_binxml_first_text(
-    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f803050105003100310032002e003500f7f7f7'
+    'dfff01b004f00472006f006f007400ef000001f801f00372006f007700ef000002f802f0045200610074006500ef000003f80305882a110000000000f7f7f7'
 );
 ----
 112.5


### PR DESCRIPTION
## Summary
- Align SSAS `application/sx` parsing with MS-BINXML scalar token families in `src/xmla.cpp`, including SQL scalar decoding paths and SQL-MONEY (`0x05`) handling in both buffered and streaming parsers.
- Harden ambiguous token handling: gate `0x01` smallint interpretation to row-cell context, preserve compact start-element behavior otherwise, and avoid false EOF errors for UTF-16 framed values during the final streaming parse pass.
- Restore legacy compact scalar compatibility (`0x13`-`0x17`) across text/value decoding and row coercion paths, and add/adjust sqllogictest coverage in `test/sql/pbi_scanner.test` for money/scalar behavior in buffered and streaming modes.

## Test plan
- [x] `./build/release/test/unittest "test/sql/pbi_scanner.test"`
- [x] `make test`
- [x] `uv run bench_native_http.py --smoke`
- [x] `uv run query_semantic_model_minimal.py`
- [x] `uv run query_semantic_model_sql_minimal.py`
- [x] `PBI_SQL_MODE=all uv run query_semantic_model_sql_minimal.py`
- [x] Live utilization query against `sm_gold` via `query_semantic_model_sql_minimal.py` (6 rows returned)