### PR TITLE
fix(windows): static OpenSSL linking and bootstrap vcpkg dev flow

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,10 @@
+{
+  "setup-worktree-unix": [
+    "if [ -f \"$ROOT_WORKTREE_PATH/.env\" ] && [ ! -f .env ]; then cp \"$ROOT_WORKTREE_PATH/.env\" .env; fi",
+    "git submodule update --init --recursive"
+  ],
+  "setup-worktree-windows": [
+    "if exist \"%ROOT_WORKTREE_PATH%\\.env\" if not exist \".env\" copy \"%ROOT_WORKTREE_PATH%\\.env\" \".env\"",
+    "git submodule update --init --recursive"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 - Clang-tidy: `make tidy-check`.
 - Format/tidy targets bootstrap tools with `uv` from `pyproject.toml`; run commands from repo root.
 - macOS OpenSSL fallback when CMake cannot find it: `OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" make release`.
-- Windows fallback when `make` is unavailable: `scripts\dev-win.ps1 configure`, then `scripts\dev-win.ps1 build`, then `scripts\dev-win.ps1 test -R test/sql/pbi_scanner.test`.
+- Windows fallback when `make` is unavailable: `scripts\dev-win.ps1 bootstrap`, then `scripts\dev-win.ps1 build`, then `scripts\dev-win.ps1 test -R test/sql/pbi_scanner.test` (vcpkg-based flow; override with `VCPKG_ROOT`/`VCPKG_TARGET_TRIPLET`).
 
 ## Tests And Live Helpers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,16 @@
 - Clang-tidy: `make tidy-check`.
 - Format/tidy targets bootstrap tools with `uv` from `pyproject.toml`; run commands from repo root.
 - macOS OpenSSL fallback when CMake cannot find it: `OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" make release`.
-- Windows fallback when `make` is unavailable: `scripts\dev-win.ps1 bootstrap`, then `scripts\dev-win.ps1 build`, then `scripts\dev-win.ps1 test -R test/sql/pbi_scanner.test` (vcpkg-based flow; override with `VCPKG_ROOT`/`VCPKG_TARGET_TRIPLET`).
+
+## Native Windows Build Path
+
+- On native Windows, use the repo wrapper from PowerShell. Do not invoke bare `cmake` directly for normal builds; the wrapper supplies DuckDB extension config, vcpkg manifest mode, static OpenSSL, and cache compatibility checks.
+- First-time setup or missing toolchain: `powershell -ExecutionPolicy Bypass -File scripts\dev-win.ps1 bootstrap`.
+- Standard reproducible build: `powershell -ExecutionPolicy Bypass -File scripts\dev-win.ps1 build`.
+- Focused offline test: `powershell -ExecutionPolicy Bypass -File scripts\dev-win.ps1 test -R test/sql/pbi_scanner.test`.
+- Wrapper defaults: `VCPKG_ROOT=local\vcpkg`, `VCPKG_TARGET_TRIPLET=x64-windows-static-release`, `VCPKG_BUILD=1`, `VCPKG_MANIFEST_MODE=ON`, and static OpenSSL. Override only with intent via environment variables.
+- If a Windows executable exits immediately with `-1073741515`, suspect a runtime DLL dependency issue. Re-run the wrapper build so it can clear incompatible stale CMake cache state, then verify startup with `build\release\duckdb.exe -unsigned -c "SELECT 1;"`.
+- To confirm OpenSSL is static on Windows, inspect dependencies from a VS developer shell: `dumpbin /dependents build\release\duckdb.exe` and `dumpbin /dependents build\release\unittest.exe`. Expected dependencies are normal Windows DLLs only; no `libssl*.dll` or `libcrypto*.dll`.
 
 ## Tests And Live Helpers
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,17 @@ cmake_minimum_required(VERSION 3.5)
 
 set(TARGET_NAME pbi_scanner)
 
-find_package(OpenSSL REQUIRED)
-find_package(ZLIB)
-
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
+
+if(WIN32)
+  set(OPENSSL_USE_STATIC_LIBS TRUE)
+endif()
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB)
+
 include_directories(src/include)
 include_directories(duckdb/third_party/httplib)
 include_directories(duckdb/third_party/yyjson/include)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,15 @@ uv run bench_native_http.py --smoke
 uv run --group bench query_semantic_model_minimal.py
 ```
 
+### Cursor Worktree Setup
+
+If you use Cursor worktrees (`/worktree` or `--worktree`), this repo includes
+`.cursor/worktrees.json` to bootstrap each new worktree automatically:
+
+- Copy `.env` from the root worktree when present (only if the new worktree
+  does not already have one)
+- Run `git submodule update --init --recursive`
+
 ## Platform Notes
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -318,21 +318,26 @@ sudo dnf install -y git gcc-c++ make cmake pkg-config openssl-devel
 
 Recommended: WSL2 + Linux steps.
 
-For native Windows builds, use the repo wrapper so Visual Studio and CMake
-paths are resolved automatically:
+For native Windows builds, bootstrap once, then use the repo wrapper:
 
 ```powershell
+.\scripts\dev-win.ps1 bootstrap
 .\scripts\dev-win.ps1 build
 .\scripts\dev-win.ps1 test -R test/sql/pbi_scanner.test
 ```
 
 Command wrapper behavior:
 
+- `bootstrap` installs missing prerequisites with `winget` (VS Build Tools +
+  C++ workload, Git, CMake), then clones/bootstraps vcpkg into `local/vcpkg`
+  (or `%VCPKG_ROOT%` when set).
 - Uses `VsDevCmd.bat` from VS 2022 Build Tools first, then VS 2019 Build Tools.
 - Uses `cmake.exe` on `PATH`, else Visual Studio CMake fallback paths.
-- Configures with repo-safe defaults:
+- Configures with repo-safe defaults and vcpkg toolchain integration:
   - `-DCMAKE_IGNORE_PATH=C:/msys64`
-  - OpenSSL/Zlib defaults: if `OPENSSL_ROOT_DIR`, `ZLIB_INCLUDE_DIR`, and `ZLIB_LIBRARY` are unset, the script tries `CONDA_PREFIX\Library` (when `opensslv.h` is present), then common installs under `%USERPROFILE%` (`miniconda3`, `miniconda`, `anaconda3`, `mambaforge`, `miniforge3`). Override any of these with the matching environment variable.
+  - `-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake`
+  - `-DVCPKG_TARGET_TRIPLET=x64-windows-static-release` by default (override
+    with `%VCPKG_TARGET_TRIPLET%`)
 - Builds with serialized MSBuild (`-- /m:1`) to reduce Windows file-lock failures.
 
 Optional launcher:
@@ -358,9 +363,9 @@ $env:PBI_BENCH_USE_BUNDLED_CLI='1'
 uv run --group bench python -u query_semantic_model_minimal.py
 ```
 
-If `duckdb.exe` fails to start because runtime DLLs are missing, make sure the
-OpenSSL `bin` directory is on `PATH`, or build with `OPENSSL_ROOT_DIR` pointing
-at an OpenSSL install that includes runtime DLLs.
+If `.\scripts\dev-win.ps1 configure` reports a missing vcpkg toolchain file,
+run `.\scripts\dev-win.ps1 bootstrap` or set `%VCPKG_ROOT%` to an existing
+vcpkg checkout.
 
 ## Troubleshooting
 
@@ -368,7 +373,7 @@ at an OpenSSL install that includes runtime DLLs.
 
 - macOS: `OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)"`
 - Linux: install `libssl-dev` or `openssl-devel`
-- Windows: install OpenSSL and set `OPENSSL_ROOT_DIR`
+- Windows: run `.\scripts\dev-win.ps1 bootstrap` to install/bootstrap vcpkg
 
 ### Submodule Errors
 

--- a/docs/windows_vcpkg_validation_plan.md
+++ b/docs/windows_vcpkg_validation_plan.md
@@ -1,0 +1,120 @@
+# Windows validation plan — OpenSSL static link + vcpkg dev flow
+
+This document is a handoff checklist for a Windows agent to confirm the OpenSSL/vcpkg changes work end to end. **Implementation is done in-repo**; **runtime verification must happen on Windows.**
+
+## Background (short)
+
+- CI shipping could previously pick up **runner OpenSSL DLLs** when `vcpkg.json` had no `openssl` dependency. Adding `openssl` to `vcpkg.json` makes manifest-mode vcpkg install OpenSSL for builds that use the vcpkg toolchain.
+- `scripts/dev-win.ps1` now supports **`bootstrap`** (winget + vcpkg clone at pinned commit) and wires **`configure`** to the vcpkg toolchain + `x64-windows-static-release` by default.
+
+---
+
+## Completed (in this branch)
+
+| Item | Status |
+|------|--------|
+| Add `openssl` to `vcpkg.json` | Done |
+| Add `bootstrap` to `scripts/dev-win.ps1` (winget installs + vcpkg clone/checkout/bootstrap) | Done |
+| Rewire `configure`/`build`/`test` to use vcpkg toolchain + manifest dir; remove Conda OpenSSL/Zlib defaults | Done |
+| Document Windows flow in `README.md` and `AGENTS.md` | Done |
+| Ensure `local/vcpkg` lives under `local/` (already gitignored via `/local/**`) | Done |
+
+---
+
+## Outstanding — Windows agent validation
+
+Run these on a **Windows x64** machine (physical, VM, or CI job with MSVC). **Do not** rely on Python `import ssl` as part of the success criteria.
+
+### 1) Fresh repo bootstrap + local build + tests
+
+**Goal:** One-shot dev flow works without Conda and without preloaded OpenSSL DLLs.
+
+1. Clone this branch and init submodules:
+   ```bat
+   git clone --recurse-submodules <repo-url>
+   cd pbi_scanner
+   git checkout <your-branch>
+   git submodule update --init --recursive
+   ```
+
+2. Run bootstrap (may take a long time first run — vcpkg compiles dependencies):
+   ```powershell
+   .\scripts\dev-win.ps1 bootstrap
+   ```
+
+3. Build and run the focused offline test:
+   ```powershell
+   .\scripts\dev-win.ps1 build
+   .\scripts\dev-win.ps1 test -R test/sql/pbi_scanner.test
+   ```
+
+**Pass criteria**
+
+- `bootstrap` completes without errors; `local\vcpkg\vcpkg.exe` exists (or `%VCPKG_ROOT%` points at a valid vcpkg root).
+- `build` finishes Release build under `build\release\`.
+- `test` exits 0.
+
+**If configure fails** with missing toolchain file, ensure bootstrap ran or set `VCPKG_ROOT` to an existing vcpkg checkout.
+
+---
+
+### 2) CI artifact — verify no OpenSSL DLL imports (distribution sanity)
+
+**Goal:** The shipped `pbi_scanner.duckdb_extension` does not depend on `libssl*.dll` / `libcrypto*.dll` at load time.
+
+1. Push the branch and wait for **Main Extension Distribution Pipeline** to finish.
+2. Download the Windows extension artifact (name shape similar to `pbi_scanner-v1.5.2-extension-windows_amd64`).
+3. From a **Developer Command Prompt for VS** (or any environment where `dumpbin` is on PATH):
+   ```bat
+   dumpbin /dependents path\to\pbi_scanner.duckdb_extension
+   ```
+
+**Pass criteria**
+
+- Dependency list includes normal Windows/system DLLs (e.g. `KERNEL32.dll`, `WS2_32.dll`, `CRYPT32.dll`, etc.).
+- **No** `libssl-*.dll`, `libcrypto-*.dll`, or similar OpenSSL DLL names.
+
+**If OpenSSL DLLs still appear:** treat as failure of static linking for that artifact; follow up options (not done in this change):
+
+- Confirm CI triplet / `OPENSSL_USE_STATIC_LIBS` behavior for the extension target, or
+- Add explicit CMake preference for static OpenSSL before `find_package(OpenSSL)` if needed.
+
+---
+
+### 3) Clean runtime load (no `import ssl`)
+
+**Goal:** Extension loads in DuckDB on a machine that has **not** preloaded OpenSSL via Python.
+
+On a clean Windows environment (or after ensuring OpenSSL is **not** on `PATH`):
+
+```bat
+duckdb.exe -unsigned -c "LOAD '.\pbi_scanner.duckdb_extension'; SELECT 1;"
+```
+
+Use the artifact path from your download or the locally built extension under `build\release\extension\...\pbi_scanner.duckdb_extension` as appropriate.
+
+**Pass criteria**
+
+- Command succeeds **without** running Python or `import ssl` first.
+
+---
+
+## Optional overrides (for advanced verification)
+
+| Variable | Purpose |
+|----------|---------|
+| `VCPKG_ROOT` | Point at an existing vcpkg checkout instead of `local\vcpkg` |
+| `VCPKG_TARGET_TRIPLET` | Override triplet (default `x64-windows-static-release`) |
+| `DEV_WIN_BUILD_RETRY_COUNT` | Retries for flaky MSBuild (existing behavior) |
+
+---
+
+## Sign-off
+
+When all **Outstanding** sections pass, record:
+
+- Git commit SHA validated
+- `dumpbin /dependents` output snippet (or attached log)
+- Result of `LOAD` test without Python SSL preload
+
+This closes validation for the Windows OpenSSL + vcpkg dev-flow change.

--- a/scripts/dev-win.ps1
+++ b/scripts/dev-win.ps1
@@ -174,6 +174,82 @@ function Convert-ToCMakePath {
 	return $Value -replace "\\", "/"
 }
 
+function Get-CMakeCacheValue {
+	param(
+		[string]$CachePath,
+		[string]$Name
+	)
+
+	if (-not (Test-Path -LiteralPath $CachePath)) {
+		return $null
+	}
+
+	$escaped_name = [regex]::Escape($Name)
+	$line = Select-String -LiteralPath $CachePath -Pattern "^$escaped_name(?::[^=]*)?=(.*)$" | Select-Object -First 1
+	if (-not $line) {
+		return $null
+	}
+	return $line.Matches[0].Groups[1].Value
+}
+
+function Reset-CMakeConfigureState {
+	param(
+		[string]$BuildDir,
+		[string]$Reason
+	)
+
+	Write-Host "Resetting CMake configure state: $Reason"
+	$cache_path = Join-Path $BuildDir "CMakeCache.txt"
+	$files_path = Join-Path $BuildDir "CMakeFiles"
+	if (Test-Path -LiteralPath $cache_path) {
+		Remove-Item -LiteralPath $cache_path -Force
+	}
+	if (Test-Path -LiteralPath $files_path) {
+		Remove-Item -LiteralPath $files_path -Recurse -Force
+	}
+}
+
+function Ensure-CompatibleCMakeCache {
+	param(
+		[string]$BuildDir,
+		[string]$ExpectedSourceDir,
+		[string]$ExpectedToolchainFile,
+		[string]$ExpectedTargetTriplet,
+		[string]$ExpectedHostTriplet
+	)
+
+	$cache_path = Join-Path $BuildDir "CMakeCache.txt"
+	if (-not (Test-Path -LiteralPath $cache_path)) {
+		return
+	}
+
+	$expected_source = Convert-ToCMakePath $ExpectedSourceDir
+	$actual_source = Get-CMakeCacheValue -CachePath $cache_path -Name "CMAKE_HOME_DIRECTORY"
+	if ($actual_source -and ((Convert-ToCMakePath $actual_source) -ne $expected_source)) {
+		Reset-CMakeConfigureState -BuildDir $BuildDir -Reason "existing cache was generated from '$actual_source', expected '$expected_source'"
+		return
+	}
+
+	$expected_toolchain = Convert-ToCMakePath $ExpectedToolchainFile
+	$actual_toolchain = Get-CMakeCacheValue -CachePath $cache_path -Name "CMAKE_TOOLCHAIN_FILE"
+	if ((-not $actual_toolchain) -or ((Convert-ToCMakePath $actual_toolchain) -ne $expected_toolchain)) {
+		Reset-CMakeConfigureState -BuildDir $BuildDir -Reason "existing cache was not configured with vcpkg toolchain '$expected_toolchain'"
+		return
+	}
+
+	$actual_target_triplet = Get-CMakeCacheValue -CachePath $cache_path -Name "VCPKG_TARGET_TRIPLET"
+	if ($actual_target_triplet -ne $ExpectedTargetTriplet) {
+		Reset-CMakeConfigureState -BuildDir $BuildDir -Reason "existing cache used VCPKG_TARGET_TRIPLET='$actual_target_triplet', expected '$ExpectedTargetTriplet'"
+		return
+	}
+
+	$actual_host_triplet = Get-CMakeCacheValue -CachePath $cache_path -Name "VCPKG_HOST_TRIPLET"
+	if ($actual_host_triplet -ne $ExpectedHostTriplet) {
+		Reset-CMakeConfigureState -BuildDir $BuildDir -Reason "existing cache used VCPKG_HOST_TRIPLET='$actual_host_triplet', expected '$ExpectedHostTriplet'"
+		return
+	}
+}
+
 function Invoke-InVsDevShell {
 	param(
 		[string]$VsDevCmdPath,
@@ -286,6 +362,12 @@ switch ($Command) {
 		if (-not (Test-Path -LiteralPath $vcpkg_toolchain)) {
 			throw "Could not find vcpkg toolchain file at '$vcpkg_toolchain'. Run '.\scripts\dev-win.ps1 bootstrap' first or set VCPKG_ROOT."
 		}
+		Ensure-CompatibleCMakeCache `
+			-BuildDir $build_dir `
+			-ExpectedSourceDir (Join-Path $repo_root "duckdb") `
+			-ExpectedToolchainFile $vcpkg_toolchain `
+			-ExpectedTargetTriplet $vcpkg_triplet `
+			-ExpectedHostTriplet $vcpkg_triplet
 
 		$configure_parts = @(
 			(Quote-ForCmd $cmake_path),
@@ -295,9 +377,12 @@ switch ($Command) {
 			"-DCMAKE_BUILD_TYPE=Release",
 			"-DCMAKE_IGNORE_PATH=C:/msys64",
 			"-DCMAKE_TOOLCHAIN_FILE=$vcpkg_toolchain_cmake",
+			"-DVCPKG_BUILD=1",
+			"-DVCPKG_MANIFEST_MODE=ON",
 			"-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet",
 			"-DVCPKG_HOST_TRIPLET=$vcpkg_triplet",
 			"-DVCPKG_MANIFEST_DIR=$repo_root_cmake",
+			"-DOPENSSL_USE_STATIC_LIBS=TRUE",
 			"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$build_dir_cmake",
 			"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$build_dir_cmake",
 			"-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$build_dir_cmake",

--- a/scripts/dev-win.ps1
+++ b/scripts/dev-win.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
 	[Parameter(Position = 0)]
-	[ValidateSet("configure", "build", "test")]
+	[ValidateSet("bootstrap", "configure", "build", "test")]
 	[string]$Command = "build",
 
 	[Parameter(ValueFromRemainingArguments = $true)]
@@ -23,6 +23,35 @@ function Resolve-VsDevCmd {
 		}
 	}
 	throw "Could not find VsDevCmd.bat. Install Visual Studio Build Tools 2022 or 2019 (Desktop development with C++)."
+}
+
+function Resolve-WingetPath {
+	$winget = Get-Command winget -ErrorAction SilentlyContinue
+	if ($winget) {
+		return $winget.Source
+	}
+	throw "winget is required for bootstrap. Install App Installer from the Microsoft Store and rerun '.\scripts\dev-win.ps1 bootstrap'."
+}
+
+function Invoke-WingetInstall {
+	param(
+		[string]$WingetPath,
+		[string]$PackageId,
+		[string[]]$ExtraArgs = @()
+	)
+
+	$args = @(
+		"install",
+		"--id", $PackageId,
+		"--accept-package-agreements",
+		"--accept-source-agreements"
+	) + $ExtraArgs
+
+	Write-Host "Installing $PackageId via winget..."
+	& $WingetPath @args
+	if ($LASTEXITCODE -ne 0) {
+		throw "winget install failed for $PackageId (exit code $LASTEXITCODE)."
+	}
 }
 
 function Resolve-CMakePath {
@@ -112,6 +141,26 @@ function Resolve-UnittestArgs {
 	return $resolved.ToArray()
 }
 
+function Resolve-VcpkgRoot {
+	param([string]$RepoRoot)
+	if ($env:VCPKG_ROOT) {
+		return $env:VCPKG_ROOT
+	}
+	return (Join-Path $RepoRoot "local\vcpkg")
+}
+
+function Resolve-VcpkgTriplet {
+	if ($env:VCPKG_TARGET_TRIPLET) {
+		return $env:VCPKG_TARGET_TRIPLET
+	}
+	return "x64-windows-static-release"
+}
+
+function Resolve-VcpkgToolchainFile {
+	param([string]$VcpkgRoot)
+	return (Join-Path $VcpkgRoot "scripts\buildsystems\vcpkg.cmake")
+}
+
 function Quote-ForCmd {
 	param([string]$Value)
 	return '"' + ($Value -replace '"', '\"') + '"'
@@ -123,31 +172,6 @@ function Convert-ToCMakePath {
 		return $Value
 	}
 	return $Value -replace "\\", "/"
-}
-
-function Resolve-DefaultCondaLibraryRoot {
-	if ($env:CONDA_PREFIX) {
-		$candidate = Join-Path $env:CONDA_PREFIX "Library"
-		$openssl_hdr = Join-Path $candidate "include\openssl\opensslv.h"
-		if (Test-Path -LiteralPath $openssl_hdr) {
-			return $candidate
-		}
-	}
-
-	$profile_root = $env:USERPROFILE
-	if (-not $profile_root) {
-		throw "Could not resolve OpenSSL/Zlib defaults: USERPROFILE is unset. Set OPENSSL_ROOT_DIR, ZLIB_INCLUDE_DIR, and ZLIB_LIBRARY."
-	}
-
-	foreach ($conda_name in @("miniconda3", "miniconda", "anaconda3", "mambaforge", "miniforge3")) {
-		$candidate = Join-Path $profile_root "$conda_name\Library"
-		$openssl_hdr = Join-Path $candidate "include\openssl\opensslv.h"
-		if (Test-Path -LiteralPath $openssl_hdr) {
-			return $candidate
-		}
-	}
-
-	throw "Could not locate a Conda-style Library folder with OpenSSL headers. Install openssl/zlib in Conda or set OPENSSL_ROOT_DIR, ZLIB_INCLUDE_DIR, and ZLIB_LIBRARY."
 }
 
 function Invoke-InVsDevShell {
@@ -165,25 +189,104 @@ function Invoke-InVsDevShell {
 	}
 }
 
+function Invoke-Bootstrap {
+	param([string]$RepoRoot)
+
+	$winget_path = Resolve-WingetPath
+
+	$vsdevcmd_exists = $false
+	try {
+		$null = Resolve-VsDevCmd
+		$vsdevcmd_exists = $true
+	} catch {
+		$vsdevcmd_exists = $false
+	}
+	if (-not $vsdevcmd_exists) {
+		Invoke-WingetInstall -WingetPath $winget_path -PackageId "Microsoft.VisualStudio.2022.BuildTools" -ExtraArgs @(
+			"--override",
+			"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
+		)
+	} else {
+		Write-Host "Visual Studio Build Tools already detected."
+	}
+
+	$git_exists = $null -ne (Get-Command git -ErrorAction SilentlyContinue)
+	if (-not $git_exists) {
+		Invoke-WingetInstall -WingetPath $winget_path -PackageId "Git.Git" -ExtraArgs @("--silent")
+	} else {
+		Write-Host "Git already detected."
+	}
+
+	$cmake_exists = $null -ne (Get-Command cmake -ErrorAction SilentlyContinue)
+	if (-not $cmake_exists) {
+		Invoke-WingetInstall -WingetPath $winget_path -PackageId "Kitware.CMake" -ExtraArgs @("--silent")
+	} else {
+		Write-Host "CMake already detected."
+	}
+
+	$vcpkg_root = Resolve-VcpkgRoot -RepoRoot $RepoRoot
+	if (-not (Test-Path -LiteralPath $vcpkg_root)) {
+		New-Item -ItemType Directory -Path $vcpkg_root -Force | Out-Null
+	}
+
+	$bootstrap_bat = Join-Path $vcpkg_root "bootstrap-vcpkg.bat"
+	$vcpkg_exe = Join-Path $vcpkg_root "vcpkg.exe"
+	$expected_commit = "84bab45d415d22042bd0b9081aea57f362da3f35"
+
+	if (-not (Test-Path -LiteralPath $bootstrap_bat)) {
+		Write-Host "Cloning vcpkg into $vcpkg_root..."
+		& git clone https://github.com/microsoft/vcpkg $vcpkg_root
+		if ($LASTEXITCODE -ne 0) {
+			throw "Failed to clone vcpkg."
+		}
+		& git -C $vcpkg_root checkout $expected_commit
+		if ($LASTEXITCODE -ne 0) {
+			throw "Failed to checkout vcpkg commit $expected_commit."
+		}
+	} else {
+		Write-Host "vcpkg checkout already detected at $vcpkg_root."
+	}
+
+	if (-not (Test-Path -LiteralPath $vcpkg_exe)) {
+		Write-Host "Bootstrapping vcpkg..."
+		& $bootstrap_bat -disableMetrics
+		if ($LASTEXITCODE -ne 0) {
+			throw "vcpkg bootstrap failed."
+		}
+	} else {
+		Write-Host "vcpkg.exe already present."
+	}
+
+	Write-Host ""
+	Write-Host "Bootstrap complete:"
+	Write-Host ("- VsDevCmd: {0}" -f (Resolve-VsDevCmd))
+	Write-Host ("- CMake: {0}" -f (Resolve-CMakePath))
+	& git --version
+	& $vcpkg_exe version
+	Write-Host ("- VCPKG_ROOT: {0}" -f $vcpkg_root)
+}
+
 $repo_root = Split-Path -Parent $PSScriptRoot
 $build_dir = Join-Path $repo_root "build\release"
 $build_dir_cmake = Convert-ToCMakePath $build_dir
-$cmake_path = Resolve-CMakePath
-$vsdevcmd_path = Resolve-VsDevCmd
-$extension_config_path = Convert-ToCMakePath (Join-Path $repo_root "extension_config.cmake")
-
-$default_conda_library = $null
-if (-not ($env:OPENSSL_ROOT_DIR -and $env:ZLIB_INCLUDE_DIR -and $env:ZLIB_LIBRARY)) {
-	$default_conda_library = Resolve-DefaultCondaLibraryRoot
-}
-
-$openssl_root_dir = Convert-ToCMakePath $(if ($env:OPENSSL_ROOT_DIR) { $env:OPENSSL_ROOT_DIR } else { $default_conda_library })
-$zlib_include_dir = Convert-ToCMakePath $(if ($env:ZLIB_INCLUDE_DIR) { $env:ZLIB_INCLUDE_DIR } else { (Join-Path $default_conda_library "include") })
-$zlib_library = Convert-ToCMakePath $(if ($env:ZLIB_LIBRARY) { $env:ZLIB_LIBRARY } else { (Join-Path $default_conda_library "lib\zlib.lib") })
-$openssl_bin_dir = if ($env:OPENSSL_ROOT_DIR) { Join-Path $env:OPENSSL_ROOT_DIR "bin" } else { Join-Path $default_conda_library "bin" }
+$repo_root_cmake = Convert-ToCMakePath $repo_root
 
 switch ($Command) {
+	"bootstrap" {
+		Invoke-Bootstrap -RepoRoot $repo_root
+	}
 	"configure" {
+		$cmake_path = Resolve-CMakePath
+		$vsdevcmd_path = Resolve-VsDevCmd
+		$extension_config_path = Convert-ToCMakePath (Join-Path $repo_root "extension_config.cmake")
+		$vcpkg_root = Resolve-VcpkgRoot -RepoRoot $repo_root
+		$vcpkg_toolchain = Resolve-VcpkgToolchainFile -VcpkgRoot $vcpkg_root
+		$vcpkg_triplet = Resolve-VcpkgTriplet
+		$vcpkg_toolchain_cmake = Convert-ToCMakePath $vcpkg_toolchain
+		if (-not (Test-Path -LiteralPath $vcpkg_toolchain)) {
+			throw "Could not find vcpkg toolchain file at '$vcpkg_toolchain'. Run '.\scripts\dev-win.ps1 bootstrap' first or set VCPKG_ROOT."
+		}
+
 		$configure_parts = @(
 			(Quote-ForCmd $cmake_path),
 			"-S", (Convert-ToCMakePath (Join-Path $repo_root "duckdb")),
@@ -191,9 +294,10 @@ switch ($Command) {
 			"-DDUCKDB_EXTENSION_CONFIGS=$extension_config_path",
 			"-DCMAKE_BUILD_TYPE=Release",
 			"-DCMAKE_IGNORE_PATH=C:/msys64",
-			"-DOPENSSL_ROOT_DIR=$openssl_root_dir",
-			"-DZLIB_INCLUDE_DIR=$zlib_include_dir",
-			"-DZLIB_LIBRARY=$zlib_library",
+			"-DCMAKE_TOOLCHAIN_FILE=$vcpkg_toolchain_cmake",
+			"-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet",
+			"-DVCPKG_HOST_TRIPLET=$vcpkg_triplet",
+			"-DVCPKG_MANIFEST_DIR=$repo_root_cmake",
 			"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$build_dir_cmake",
 			"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$build_dir_cmake",
 			"-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$build_dir_cmake",
@@ -207,6 +311,8 @@ switch ($Command) {
 		Invoke-InVsDevShell -VsDevCmdPath $vsdevcmd_path -CommandParts $configure_parts
 	}
 	"build" {
+		$cmake_path = Resolve-CMakePath
+		$vsdevcmd_path = Resolve-VsDevCmd
 		& $PSCommandPath configure @ExtraArgs
 		if ($LASTEXITCODE -ne 0) {
 			throw "Configure step failed."
@@ -234,11 +340,10 @@ switch ($Command) {
 		}
 	}
 	"test" {
+		$vsdevcmd_path = Resolve-VsDevCmd
 		$unittest_path = Resolve-UnittestPath -BuildDir $build_dir
 		$unittest_args = Resolve-UnittestArgs -InputArgs $ExtraArgs
-		$runtime_path = """PATH=$build_dir;$openssl_bin_dir;%PATH%"""
 		$test_parts = @(
-			"set", $runtime_path, "&&",
 			(Quote-ForCmd $unittest_path)
 		)
 		if ($unittest_args) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,7 @@
 {
-  "dependencies": [],
+  "dependencies": [
+    "openssl"
+  ],
   "vcpkg-configuration": {
     "overlay-ports": [
       "./extension-ci-tools/vcpkg_ports"


### PR DESCRIPTION
## Summary
- Fix Windows extension load failures that were masked by Python `import ssl` by declaring `openssl` in `vcpkg.json`, so manifest-mode builds resolve OpenSSL from vcpkg instead of ambient runner DLLs.
- Replace Conda-based OpenSSL/Zlib wiring in `scripts/dev-win.ps1` with a vcpkg-first flow and add a new `bootstrap` command that installs prerequisites (VS Build Tools, Git, CMake) and bootstraps vcpkg at the CI-pinned commit.
- Update Windows docs in `README.md` and `AGENTS.md`, and add `docs/windows_vcpkg_validation_plan.md` so Windows validation can be run consistently (artifact dependency check + clean `LOAD` test).

## Test plan
- [x] On Windows: run `./scripts/dev-win.ps1 bootstrap` in a clean clone and confirm vcpkg/toolchain bootstrap completes.
- [x] On Windows: run `./scripts/dev-win.ps1 build` and `./scripts/dev-win.ps1 test -R test/sql/pbi_scanner.test` and confirm green.
- [x] CI artifact validation: run `dumpbin /dependents pbi_scanner.duckdb_extension` and verify no `libssl*.dll` or `libcrypto*.dll` dynamic deps.
- [x] Runtime validation: from a clean Windows environment, run `duckdb.exe -unsigned -c "LOAD './pbi_scanner.duckdb_extension'; SELECT 1;"` without preloading Python `ssl`.