### PR TITLE
Add WASM sqllogictest harness for offline validation in browser

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -52,3 +52,10 @@ jobs:
           PBI_WASM_DUCKDB_PLATFORM: ${{ matrix.duckdb_platform }}
         run: node smoke.mjs
         working-directory: test/wasm
+
+      - name: Run WASM sqllogictest
+        env:
+          PBI_WASM_EXTENSION_PATH: build/${{ matrix.duckdb_platform }}/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm
+          PBI_WASM_DUCKDB_PLATFORM: ${{ matrix.duckdb_platform }}
+        run: node run_sqllogictest.mjs --test ../../test/sql/pbi_scanner_wasm.test
+        working-directory: test/wasm

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -57,5 +57,5 @@ jobs:
         env:
           PBI_WASM_EXTENSION_PATH: build/${{ matrix.duckdb_platform }}/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm
           PBI_WASM_DUCKDB_PLATFORM: ${{ matrix.duckdb_platform }}
-        run: node run_sqllogictest.mjs --test ../../test/sql/pbi_scanner_wasm.test
+        run: node run_sqllogictest.mjs --test ../../wasm_sql/pbi_scanner_wasm.test
         working-directory: test/wasm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,10 @@
   `build/<platform>/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm`.
 - Browser smoke test: `uv run test/wasm/run_pbi_wasm_smoke.py --build` (add
   `--platform wasm_mvp` for the MVP artifact).
+- Browser sqllogictest: `uv run test/wasm/run_pbi_wasm_sqllogictest.py --build`
+  (runs `test/sql/pbi_scanner_wasm.test` in Chromium via DuckDB-Wasm).
 - CI runs `.github/workflows/wasm-smoke.yml` on `wasm_eh` and `wasm_mvp` for
-  every push and pull request.
+  every push and pull request (smoke plus `pbi_scanner_wasm.test`).
 - Browser auth is `access_token` only; see [docs/wasm.md](docs/wasm.md).
 - On Windows, prefer WSL/Linux or CI for Emscripten builds; native Windows uses
   `scripts\dev-win.ps1` for release/unittest only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - This repo builds a DuckDB C++ extension named `pbi_scanner` for querying Power BI Semantic Models through DAX/XMLA.
-- Normal edit surface: `src/`, `src/include/`, `test/sql/`, `test/wasm/`, `README.md`, `CMakeLists.txt`, and `extension_config.cmake`.
+- Normal edit surface: `src/`, `src/include/`, `test/sql/`, `test/wasm/`, `wasm_sql/`, `README.md`, `CMakeLists.txt`, and `extension_config.cmake`.
 - Treat `duckdb/` and `extension-ci-tools/` as pinned upstream/vendor trees; do not edit them unless the task explicitly requires it.
 - Current stable target is DuckDB `v1.5.3`; CI also has a forward-compatibility build against DuckDB `main`.
 
@@ -37,7 +37,7 @@
 - Browser smoke test: `uv run test/wasm/run_pbi_wasm_smoke.py --build` (add
   `--platform wasm_mvp` for the MVP artifact).
 - Browser sqllogictest: `uv run test/wasm/run_pbi_wasm_sqllogictest.py --build`
-  (runs `test/sql/pbi_scanner_wasm.test` in Chromium via DuckDB-Wasm).
+  (runs `wasm_sql/pbi_scanner_wasm.test` in Chromium via DuckDB-Wasm).
 - Convenience target (after `make wasm_eh`): `make test-pbi-wasm` runs smoke plus
   sqllogictest on `wasm_eh`.
 - CI runs `.github/workflows/wasm-smoke.yml` on `wasm_eh` and `wasm_mvp` for
@@ -65,8 +65,9 @@
 - Tests under `test/sql/` must be deterministic and offline; do not add live Power BI/Azure requirements there.
 - Prefer sqllogictest coverage for extension behavior, especially user-visible validation errors.
 - If an error message or parse rule changes, update exact `statement error` expectations in
-  `test/sql/pbi_scanner.test` for native paths and `test/sql/pbi_scanner_wasm.test` for
-  WASM/browser paths.
+  `test/sql/pbi_scanner.test` for native paths and `wasm_sql/pbi_scanner_wasm.test` for
+  WASM/browser paths. Keep WASM sqllogictest files outside `test/` so native
+  `unittest` does not execute them.
 - Offline smoke helper: `uv run bench_native_http.py --smoke` (LOAD + `dax_query` registration, then Catch `[smoke]` tests).
 - Optional bind tuning: `PBI_SCANNER_SCHEMA_PROBE_ROWS` sets the default limited schema probe row count (override per query with `schema_probe_rows := ...`).
 - Live benchmark/helper: `uv run --group bench query_semantic_model_minimal.py`; use `PBI_BENCH_*` env vars and keep real workspace IDs/secrets in env, `.env` (gitignored), or `local/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - This repo builds a DuckDB C++ extension named `pbi_scanner` for querying Power BI Semantic Models through DAX/XMLA.
-- Normal edit surface: `src/`, `src/include/`, `test/sql/`, `README.md`, `CMakeLists.txt`, and `extension_config.cmake`.
+- Normal edit surface: `src/`, `src/include/`, `test/sql/`, `test/wasm/`, `README.md`, `CMakeLists.txt`, and `extension_config.cmake`.
 - Treat `duckdb/` and `extension-ci-tools/` as pinned upstream/vendor trees; do not edit them unless the task explicitly requires it.
 - Current stable target is DuckDB `v1.5.3`; CI also has a forward-compatibility build against DuckDB `main`.
 
@@ -30,7 +30,7 @@
 - Format/tidy targets bootstrap tools with `uv` from `pyproject.toml`; run commands from repo root.
 - macOS OpenSSL fallback when CMake cannot find it: `OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" make release`.
 
-## DuckDB-Wasm Build And Smoke
+## DuckDB-Wasm Build And Test
 
 - Build artifacts: `make wasm_eh` (primary) or `make wasm_mvp`; output under
   `build/<platform>/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm`.
@@ -38,9 +38,15 @@
   `--platform wasm_mvp` for the MVP artifact).
 - Browser sqllogictest: `uv run test/wasm/run_pbi_wasm_sqllogictest.py --build`
   (runs `test/sql/pbi_scanner_wasm.test` in Chromium via DuckDB-Wasm).
+- Convenience target (after `make wasm_eh`): `make test-pbi-wasm` runs smoke plus
+  sqllogictest on `wasm_eh`.
 - CI runs `.github/workflows/wasm-smoke.yml` on `wasm_eh` and `wasm_mvp` for
   every push and pull request (smoke plus `pbi_scanner_wasm.test`).
-- Browser auth is `access_token` only; see [docs/wasm.md](docs/wasm.md).
+- Architecture: [docs/wasm_testing_plan.md](docs/wasm_testing_plan.md); commands
+  and limitations: [docs/wasm.md](docs/wasm.md).
+- Browser auth is `access_token` only.
+- On `wasm_mvp`, smoke negative checks and sqllogictest `statement error` records
+  are skipped (DuckDB-Wasm MVP runtime glue hides extension error messages).
 - On Windows, prefer WSL/Linux or CI for Emscripten builds; native Windows uses
   `scripts\dev-win.ps1` for release/unittest only.
 
@@ -58,7 +64,9 @@
 
 - Tests under `test/sql/` must be deterministic and offline; do not add live Power BI/Azure requirements there.
 - Prefer sqllogictest coverage for extension behavior, especially user-visible validation errors.
-- If an error message or parse rule changes, update exact `statement error` expectations in `test/sql/pbi_scanner.test`.
+- If an error message or parse rule changes, update exact `statement error` expectations in
+  `test/sql/pbi_scanner.test` for native paths and `test/sql/pbi_scanner_wasm.test` for
+  WASM/browser paths.
 - Offline smoke helper: `uv run bench_native_http.py --smoke` (LOAD + `dax_query` registration, then Catch `[smoke]` tests).
 - Optional bind tuning: `PBI_SCANNER_SCHEMA_PROBE_ROWS` sets the default limited schema probe row count (override per query with `schema_probe_rows := ...`).
 - Live benchmark/helper: `uv run --group bench query_semantic_model_minimal.py`; use `PBI_BENCH_*` env vars and keep real workspace IDs/secrets in env, `.env` (gitignored), or `local/`.

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,32 @@ EXT_NAME=pbi_scanner
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 export PATH := ${PROJ_DIR}.venv/bin:${PATH}
 
-# DuckDB v1.5.3 bundles fmt that uses stdext::checked_array_iterator, removed in
-# Visual Studio 2026 (windows-latest). Undefine _SECURE_SCL (/D=0 still leaves
-# #ifdef _SECURE_SCL true) so fmt uses the non-stdext path.
+FMT_FORMAT_H := $(DUCKDB_SRCDIR)third_party/fmt/include/fmt/format.h
+
+# DuckDB v1.5.3 fmt uses stdext::checked_array_iterator, removed in VS 2026.
 ifeq ($(DUCKDB_PLATFORM),windows_amd64)
-EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
-EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
+.PHONY: patch-fmt-vs2026
+patch-fmt-vs2026:
+	python $(PROJ_DIR)scripts/patch_fmt_vs2026.py $(FMT_FORMAT_H)
 else ifeq ($(DUCKDB_PLATFORM),windows_arm64)
-EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
-EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
+.PHONY: patch-fmt-vs2026
+patch-fmt-vs2026:
+	python $(PROJ_DIR)scripts/patch_fmt_vs2026.py $(FMT_FORMAT_H)
 endif
 
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+ifeq ($(DUCKDB_PLATFORM),windows_amd64)
+release: patch-fmt-vs2026
+debug: patch-fmt-vs2026
+reldebug: patch-fmt-vs2026
+relassert: patch-fmt-vs2026
+else ifeq ($(DUCKDB_PLATFORM),windows_arm64)
+release: patch-fmt-vs2026
+debug: patch-fmt-vs2026
+reldebug: patch-fmt-vs2026
+relassert: patch-fmt-vs2026
+endif
 
 .PHONY: pbi_scanner_unit_tests test-pbi-offline test-pbi-wasm
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
-FMT_FORMAT_H := $(DUCKDB_SRCDIR)third_party/fmt/include/fmt/format.h
+FMT_FORMAT_H := $(DUCKDB_SRCDIR)/third_party/fmt/include/fmt/format.h
 
 ifeq ($(DUCKDB_PLATFORM),windows_amd64)
 release: patch-fmt-vs2026

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ EXT_NAME=pbi_scanner
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 export PATH := ${PROJ_DIR}.venv/bin:${PATH}
 
+# DuckDB v1.5.3 bundles fmt that uses stdext::checked_array_iterator, removed in
+# Visual Studio 2026 (windows-latest). Disable _SECURE_SCL so fmt compiles.
+ifeq ($(DUCKDB_PLATFORM),windows_amd64)
+EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
+EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
+else ifeq ($(DUCKDB_PLATFORM),windows_arm64)
+EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
+EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
+endif
+
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 .PHONY: pbi_scanner_unit_tests test-pbi-offline test-pbi-wasm

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ EXT_NAME=pbi_scanner
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 export PATH := ${PROJ_DIR}.venv/bin:${PATH}
 
-FMT_FORMAT_H := $(DUCKDB_SRCDIR)third_party/fmt/include/fmt/format.h
-
 # DuckDB v1.5.3 fmt uses stdext::checked_array_iterator, removed in VS 2026.
 ifeq ($(DUCKDB_PLATFORM),windows_amd64)
 .PHONY: patch-fmt-vs2026
@@ -18,6 +16,8 @@ patch-fmt-vs2026:
 endif
 
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+FMT_FORMAT_H := $(DUCKDB_SRCDIR)third_party/fmt/include/fmt/format.h
 
 ifeq ($(DUCKDB_PLATFORM),windows_amd64)
 release: patch-fmt-vs2026

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export PATH := ${PROJ_DIR}.venv/bin:${PATH}
 
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
-.PHONY: pbi_scanner_unit_tests test-pbi-offline
+.PHONY: pbi_scanner_unit_tests test-pbi-offline test-pbi-wasm
 
 # BUILD_DIR selects release/debug/reldebug output (default: build/release).
 pbi_scanner_unit_tests:
@@ -34,6 +34,10 @@ test_reldebug_internal:
 
 test-pbi-offline: pbi_scanner_unit_tests
 	./build/release/test/unittest "test/sql/pbi_scanner.test"
+
+test-pbi-wasm:
+	uv run test/wasm/run_pbi_wasm_smoke.py --platform wasm_eh
+	uv run test/wasm/run_pbi_wasm_sqllogictest.py --platform wasm_eh
 
 .PHONY: ensure-uv
 ensure-uv:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,13 @@ ensure-format-tools: ensure-uv
 	fi; \
 	$$UV_CMD run --group format black --version >/dev/null
 
-format-check format format-fix: ensure-format-tools
+format-check: ensure-format-tools
+	python3 duckdb/scripts/format.py --all --check --directories src test wasm_sql
+
+format-fix: ensure-format-tools
+	python3 duckdb/scripts/format.py --all --fix --noconfirm --directories src test wasm_sql
+
+format: format-fix
 
 .PHONY: ensure-tidy-tools
 ensure-tidy-tools: ensure-uv

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 export PATH := ${PROJ_DIR}.venv/bin:${PATH}
 
 # DuckDB v1.5.3 bundles fmt that uses stdext::checked_array_iterator, removed in
-# Visual Studio 2026 (windows-latest). Disable _SECURE_SCL so fmt compiles.
+# Visual Studio 2026 (windows-latest). Undefine _SECURE_SCL (/D=0 still leaves
+# #ifdef _SECURE_SCL true) so fmt uses the non-stdext path.
 ifeq ($(DUCKDB_PLATFORM),windows_amd64)
-EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
-EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
+EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
+EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
 else ifeq ($(DUCKDB_PLATFORM),windows_arm64)
-EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
-EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/D_SECURE_SCL=0"
+EXT_RELEASE_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
+EXT_DEBUG_FLAGS += -DCMAKE_CXX_FLAGS="/U_SECURE_SCL"
 endif
 
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ For browser DuckDB-Wasm usage, use `auth_mode := 'access_token'` and pass a
 short-lived token from the host application. Native auth paths such as
 `azure_cli`, browser-side `service_principal`, and Azure credential-chain
 secrets are intentionally unsupported in browser WASM. See
-[docs/wasm.md](docs/wasm.md) for build, loading, CORS/proxy, and smoke-test
-details.
+[docs/wasm.md](docs/wasm.md) for build, testing, CORS/proxy, and browser
+validation details.
 
 ### Step 1: Clone and Build
 
@@ -326,6 +326,20 @@ make test-pbi-offline
 ./build/release/test/unittest "test/sql/pbi_scanner.test"
 ./build/release/pbi_scanner_unit_tests
 ```
+
+DuckDB-Wasm validation (requires Emscripten 3.1.64; see [docs/wasm.md](docs/wasm.md)):
+
+```bash
+make wasm_eh
+uv run test/wasm/run_pbi_wasm_smoke.py --build
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --build
+# or, after building wasm_eh:
+make test-pbi-wasm
+```
+
+Browser smoke proves load, mock XMLA HTTP, and auth-header propagation. Browser
+sqllogictest runs `test/sql/pbi_scanner_wasm.test` for offline WASM-specific SQL
+assertions. Architecture notes: [docs/wasm_testing_plan.md](docs/wasm_testing_plan.md).
 
 ### Quality Checks
 

--- a/README.md
+++ b/README.md
@@ -338,8 +338,9 @@ make test-pbi-wasm
 ```
 
 Browser smoke proves load, mock XMLA HTTP, and auth-header propagation. Browser
-sqllogictest runs `test/sql/pbi_scanner_wasm.test` for offline WASM-specific SQL
-assertions. Architecture notes: [docs/wasm_testing_plan.md](docs/wasm_testing_plan.md).
+sqllogictest runs `wasm_sql/pbi_scanner_wasm.test` for offline WASM-specific SQL
+assertions (kept outside `test/` so native `unittest` does not pick it up).
+Architecture notes: [docs/wasm_testing_plan.md](docs/wasm_testing_plan.md).
 
 ### Quality Checks
 

--- a/docs/release_publication.md
+++ b/docs/release_publication.md
@@ -19,6 +19,9 @@ git -C extension-ci-tools rev-parse HEAD
 make format-check
 make release
 ./build/release/test/unittest "test/sql/pbi_scanner.test"
+make wasm_eh
+uv run test/wasm/run_pbi_wasm_smoke.py --platform wasm_eh
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --platform wasm_eh
 make tidy-check
 ```
 
@@ -39,6 +42,9 @@ git status --short --branch
 make format-check
 make release
 ./build/release/test/unittest "test/sql/pbi_scanner.test"
+make wasm_eh
+uv run test/wasm/run_pbi_wasm_smoke.py --platform wasm_eh
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --platform wasm_eh
 make tidy-check
 git add extension_config.cmake README.md .github/workflows/MainDistributionPipeline.yml pyproject.toml uv.lock
 git commit -m "Prepare pbi_scanner X.Y.Z release"
@@ -91,4 +97,7 @@ git push -u origin HEAD
 gh pr create --repo duckdb/community-extensions --base main --head <fork-owner>:pbi_scanner-vX.Y.Z --title "Update pbi_scanner to X.Y.Z" --body "<validation evidence>"
 ```
 
-Community PR validation evidence should include stable CI, next CI if available, local build/test commands, release tag, release commit SHA, and known platform exclusions.
+Community PR validation evidence should include stable CI, next CI if available,
+local build/test commands, release tag, release commit SHA, known platform
+exclusions, and WASM smoke plus sqllogictest green when shipping `wasm_eh` /
+`wasm_mvp` artifacts.

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -28,8 +28,22 @@ uv run test/wasm/run_pbi_wasm_smoke.py --build
 uv run test/wasm/run_pbi_wasm_smoke.py --build --platform wasm_mvp
 ```
 
+Run the WASM sqllogictest suite with:
+
+```bash
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --build
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --build --platform wasm_mvp
+```
+
+On `wasm_mvp`, statement-error records are skipped because deliberate validation
+errors currently surface as DuckDB-Wasm MVP runtime glue errors instead of the
+extension's `InvalidInputException` messages.
+
 GitHub Actions runs the same smoke for both `wasm_eh` and `wasm_mvp` via
-`.github/workflows/wasm-smoke.yml`.
+`.github/workflows/wasm-smoke.yml`. The workflow also runs
+`test/sql/pbi_scanner_wasm.test` through a browser sqllogictest harness so WASM
+validation covers the extension's offline SQL assertions, not just load/execute
+smoke.
 
 The smoke test starts a local Playwright/Chromium browser, serves DuckDB-Wasm
 assets and the extension artifact from a local unsigned extension repository,

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -96,8 +96,9 @@ uv run test/wasm/run_pbi_wasm_sqllogictest.py --build --platform wasm_mvp
 
 The sqllogictest harness (`test/wasm/run_sqllogictest.mjs`) uses the same browser
 runtime and shared asset server (`test/wasm/browser_harness.mjs`) but executes
-records from `test/sql/pbi_scanner_wasm.test` instead of the native
-`test/sql/pbi_scanner.test` file.
+records from `wasm_sql/pbi_scanner_wasm.test` instead of the native
+`test/sql/pbi_scanner.test` file. WASM sqllogictest files live under `wasm_sql/`
+(not `test/`) so DuckDB's native `unittest` sweep does not execute them.
 
 Why a separate test file: native sqllogictest includes `powerbi://` cases that
 reach resolver/auth validation in the C++ `unittest` binary. In WASM, `powerbi://`

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -19,36 +19,40 @@ The expected local artifact is:
 build/wasm_eh/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm
 ```
 
-## Smoke Test
+## Testing
 
-Run the credential-free browser WASM smoke test with:
+WASM validation has two layers. See [wasm_testing_plan.md](wasm_testing_plan.md)
+for architecture and rationale.
+
+### Prerequisites
+
+- Emscripten **3.1.64** (CI uses `mymindstorm/setup-emsdk@v13`)
+- Node 20+
+- From `test/wasm/`: `npm ci` and `npx playwright install --with-deps chromium`
+- Optional env vars:
+  - `PBI_WASM_EXTENSION_PATH` — path to `pbi_scanner.duckdb_extension.wasm`
+    (default: `build/wasm_eh/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm`)
+  - `PBI_WASM_DUCKDB_PLATFORM` — `wasm_eh` or `wasm_mvp` (default: `wasm_eh`)
+
+After `make wasm_eh`, a convenience target runs both layers:
+
+```bash
+make test-pbi-wasm
+```
+
+### Browser smoke
+
+Run the credential-free end-to-end smoke with:
 
 ```bash
 uv run test/wasm/run_pbi_wasm_smoke.py --build
 uv run test/wasm/run_pbi_wasm_smoke.py --build --platform wasm_mvp
 ```
 
-Run the WASM sqllogictest suite with:
-
-```bash
-uv run test/wasm/run_pbi_wasm_sqllogictest.py --build
-uv run test/wasm/run_pbi_wasm_sqllogictest.py --build --platform wasm_mvp
-```
-
-On `wasm_mvp`, statement-error records are skipped because deliberate validation
-errors currently surface as DuckDB-Wasm MVP runtime glue errors instead of the
-extension's `InvalidInputException` messages.
-
-GitHub Actions runs the same smoke for both `wasm_eh` and `wasm_mvp` via
-`.github/workflows/wasm-smoke.yml`. The workflow also runs
-`test/sql/pbi_scanner_wasm.test` through a browser sqllogictest harness so WASM
-validation covers the extension's offline SQL assertions, not just load/execute
-smoke.
-
-The smoke test starts a local Playwright/Chromium browser, serves DuckDB-Wasm
-assets and the extension artifact from a local unsigned extension repository,
-serves a same-origin mock XMLA endpoint, loads `pbi_scanner` in
-`@duckdb/duckdb-wasm`, verifies the SQL table functions are registered, and runs:
+The smoke harness (`test/wasm/smoke.mjs`) starts Playwright/Chromium, serves
+DuckDB-Wasm assets and the extension from a local unsigned repository, serves a
+same-origin mock XMLA endpoint, loads `pbi_scanner` in `@duckdb/duckdb-wasm`,
+verifies the SQL table functions are registered, and runs:
 
 ```sql
 SELECT *
@@ -74,16 +78,43 @@ error-message assertions. In the current DuckDB-Wasm MVP runtime, deliberate
 validation errors surface as runtime glue errors instead of the extension's
 `InvalidInputException` messages.
 
-Set `PBI_WASM_DUCKDB_PLATFORM` to `wasm_eh` or `wasm_mvp` when running smoke so
-the DuckDB-Wasm core matches the extension artifact (CI sets this from the matrix
-leg). When unset, smoke defaults to `wasm_eh`.
-
 The mock XMLA endpoint is intentionally same-origin with the browser page. The
 WASM HTTP client uses synchronous browser XHR; Chromium blocks synchronous
 cross-origin loopback XHR before the mock server receives a request, even with
 CORS headers. The smoke therefore validates the documented browser proxy shape:
 host applications should either call same-origin/loopback XMLA URLs or route
 cross-origin XMLA traffic through a backend/proxy with appropriate CORS policy.
+
+### Browser sqllogictest
+
+Run offline SQL assertions against DuckDB-Wasm with:
+
+```bash
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --build
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --build --platform wasm_mvp
+```
+
+The sqllogictest harness (`test/wasm/run_sqllogictest.mjs`) uses the same browser
+runtime and shared asset server (`test/wasm/browser_harness.mjs`) but executes
+records from `test/sql/pbi_scanner_wasm.test` instead of the native
+`test/sql/pbi_scanner.test` file.
+
+Why a separate test file: native sqllogictest includes `powerbi://` cases that
+reach resolver/auth validation in the C++ `unittest` binary. In WASM, `powerbi://`
+fails earlier at bind time with a browser-specific message. WASM tests use direct
+or loopback XMLA URLs where validation stages match the browser build.
+
+Supported directives: `query`, `statement ok`, `statement error`, `require`.
+Unsupported sqllogictest features (`loop`, `foreach`, hash results, multiple
+connections, etc.) are out of scope.
+
+On `wasm_mvp`, `statement error` records are skipped (same MVP runtime limitation
+as smoke negative checks). `wasm_eh` runs the full WASM sqllogictest file.
+
+### CI
+
+GitHub Actions runs smoke and sqllogictest for both `wasm_eh` and `wasm_mvp` via
+`.github/workflows/wasm-smoke.yml` on every push and pull request.
 
 ## Optional Live Semantic Model Test
 

--- a/docs/wasm_testing_plan.md
+++ b/docs/wasm_testing_plan.md
@@ -1,129 +1,105 @@
-# WASM Testing Plan
+# WASM Validation Architecture
 
-Plan to validate `feature/wasm-support` end-to-end: the extension builds, loads in DuckDB-Wasm in a real browser runtime, and runs a credential-free `dax_query` smoke against a local mock XMLA endpoint on CI and locally.
+How `pbi_scanner` validates DuckDB-Wasm builds beyond compile-only CI. WASM
+extensions are Emscripten side modules: a green link step does not prove the
+artifact loads, resolves symbols, or runs usefully in a browser. See also
+[Compiling Isn't Running: Functionally Testing DuckDB-WASM Extensions](https://rusty.today/blog/testing-duckdb-wasm-extensions/).
 
-## Goal
+Operational commands and toolchain pins live in [wasm.md](wasm.md). Agent
+entry points are in [AGENTS.md](../AGENTS.md).
 
-Prove WASM support works end-to-end before merging the feature branch.
+## Two Validation Layers
 
-## Where Things Stand
+| Layer | Harness | What it proves |
+|-------|---------|----------------|
+| **Browser smoke** | `test/wasm/smoke.mjs` | `INSTALL`/`LOAD`, function registration, same-origin mock XMLA HTTP, auth header propagation, XMLA parse/result materialization, and (`wasm_eh` only) native-only path rejection |
+| **Browser sqllogictest** | `test/wasm/run_sqllogictest.mjs` | Offline SQL assertions from `test/sql/pbi_scanner_wasm.test` — validation errors, WASM auth restrictions, `powerbi://` bind rejection — without live Power BI |
 
-The feature branch now has a working local and CI WASM validation path:
+Both run DuckDB-Wasm inside Chromium via Playwright. Node only serves assets and
+drives the browser; SQL executes in the same runtime shape production uses.
 
-- WASM artifacts compile locally (`make wasm_eh` / `make wasm_mvp`)
-- Native offline tests pass (including platform capability hooks)
-- Dedicated WASM smoke CI passes for `wasm_eh` and `wasm_mvp`
-- Distribution CI builds `wasm_eh` and `wasm_mvp` artifacts successfully
-- The smoke harness runs DuckDB-Wasm in Chromium through Playwright; Node only starts local servers and drives the browser
+Shared asset serving (extension repo layout, DuckDB-Wasm bundles, mock XMLA,
+CORS) lives in `test/wasm/browser_harness.mjs`.
 
-### Local Checkpoint: 2026-06-06
+## Native vs WASM Test Files
 
-- `make wasm_eh` passes locally and produces `build/wasm_eh/repository/v1.5.3/wasm_eh/pbi_scanner.duckdb_extension.wasm`
-- `make wasm_mvp` passes locally after clearing stale Homebrew Emscripten CMake state and rebuilding with emsdk 3.1.64
-- `uv run test/wasm/run_pbi_wasm_smoke.py --platform wasm_eh` passes locally with negative checks enabled
-- `uv run test/wasm/run_pbi_wasm_smoke.py --platform wasm_mvp` passes locally with success-path checks enabled and negative checks skipped
+| File | Runtime | Scope |
+|------|---------|-------|
+| `test/sql/pbi_scanner.test` | Native `unittest` | Full offline validation including `powerbi://` resolver/auth paths |
+| `test/sql/pbi_scanner_wasm.test` | Browser DuckDB-Wasm | WASM-portable cases: direct/loopback XMLA URLs, browser auth limits, earlier `powerbi://` bind failure |
 
-### Browser Smoke Checkpoint: 2026-06-06
+Do not run the native file unmodified against WASM — several `powerbi://`
+records reach different validation stages on native vs browser.
 
-- Replaced the Node DuckDB-Wasm runtime with a Playwright/Chromium browser smoke
-- `@duckdb/duckdb-wasm@1.29.0` embeds DuckDB `v1.1.1` and cannot load the `v1.5.3` extension
-- `@duckdb/duckdb-wasm@1.32.0` embeds DuckDB `v1.4.3` and is still not compatible enough for this smoke
-- `@duckdb/duckdb-wasm@1.33.1-dev55.0` embeds DuckDB `v1.5.3` and successfully loads the `wasm_eh` extension
-- Cross-origin synchronous XHR to a separate loopback XMLA server is blocked by Chromium before the mock server receives a request
-- Same-origin browser/proxy smoke passes for `wasm_eh`: `dax_query` returns `probe_ok = 1`, the mock endpoint sees `Authorization: Bearer mock-token`, and native-only auth/locator paths fail clearly
-- `wasm_mvp` builds locally after clearing stale Homebrew Emscripten CMake state and rebuilding with emsdk 3.1.64
-- Same-origin browser/proxy smoke passes for `wasm_mvp`: `dax_query` returns `probe_ok = 1` and the mock endpoint sees `Authorization: Bearer mock-token`
-- `wasm_mvp` negative error-message checks are skipped because deliberate validation errors currently surface as DuckDB-Wasm MVP runtime glue errors (`_setThrew is not defined`) instead of the extension's `InvalidInputException` messages
+When changing user-visible error text:
 
-### CI Checkpoint: 2026-06-06
+- Native paths → update `pbi_scanner.test`
+- WASM/browser paths → update `pbi_scanner_wasm.test`
 
-- `WASM Smoke Test` passes for both `wasm_eh` and `wasm_mvp` on commit `697bc94`
-- `Main Extension Distribution Pipeline` passes on commit `697bc94`
-- Stable distribution CI builds and uploads both WASM artifacts (`wasm_eh` and `wasm_mvp`) on commit `697bc94`
-- DuckDB-main forward-compatibility CI builds both WASM artifacts (`wasm_eh` and `wasm_mvp`) on commit `697bc94`
+## CI
 
-## Guiding Principle
+`.github/workflows/wasm-smoke.yml` on every push/PR:
 
-Keep the validation small, but test the real runtime shape. Use Node only to start local servers and drive the test; run DuckDB-Wasm itself inside a browser page. Browser HTTP should be validated through a same-origin loopback/proxy path because Chromium blocks the extension's synchronous cross-origin XHR before a separate mock XMLA server receives the request.
+1. Build `wasm_eh` or `wasm_mvp` (matrix leg)
+2. Run browser smoke
+3. Run browser sqllogictest against `pbi_scanner_wasm.test`
 
-## Plan
+Distribution CI still builds and uploads both WASM artifacts via the main
+extension pipeline.
 
-### 1. Get CI Building Both WASM Platforms
+## Platform Notes
 
-Push the fixes already on the branch (emsdk setup, formatting, HTTP stop-flag access) and confirm CI builds `wasm_eh` and `wasm_mvp` on every push.
+### `wasm_eh` (primary)
 
-**Outcome:** Reliable compile signal on Ubuntu with Emscripten 3.1.64 and Node 20 — without requiring HTTP to work yet.
+- Full smoke coverage including negative auth/locator checks
+- All sqllogictest records run (queries + `statement error`)
 
-### 2. Replace Node Runtime Smoke With Browser Smoke
+### `wasm_mvp`
 
-Move the smoke runtime into a real browser page, driven by Playwright or an equivalent browser runner:
+- Smoke success path only; negative error-message checks skipped
+- Sqllogictest skips `statement error` records — deliberate
+  `InvalidInputException` messages currently surface as DuckDB-Wasm MVP runtime
+  glue errors (`_setThrew is not defined`) instead of extension text
 
-- Start a local server for the page, DuckDB-Wasm assets, extension artifact, and same-origin mock XMLA endpoint
-- Open a browser page that instantiates `@duckdb/duckdb-wasm`
-- Select the DuckDB-Wasm bundle matching the extension platform under test (`wasm_eh` or `wasm_mvp`)
-- Run `INSTALL`, `LOAD pbi_scanner`, and the smoke SQL from inside the page
+Use `wasm_eh` for functional proof; keep `wasm_mvp` in CI as a compile/load
+regression leg.
 
-**Outcome:** The test validates the same browser APIs the extension will use in production, instead of validating a Node/worker/XHR shim combination.
+### `wasm_threads`
 
-### 3. Validate The End-To-End Success Path
+Excluded until the harness covers COOP/COEP and pthread deployment requirements.
 
-Run the credential-free `dax_query` path against the same-origin mock XMLA endpoint:
+## Local Commands
 
-- `dax_query` returns `probe_ok = 1`
-- The mock XMLA server receives `Authorization: Bearer mock-token`
-- The test passes for both `wasm_eh` and `wasm_mvp`
+```bash
+make wasm_eh
+uv run test/wasm/run_pbi_wasm_smoke.py --build
+uv run test/wasm/run_pbi_wasm_sqllogictest.py --build
+make test-pbi-wasm    # smoke + sqllogictest on wasm_eh (expects artifact already built)
+```
 
-**Outcome:** Full browser smoke proves build, load, registration, HTTP, auth-header propagation, XMLA parsing, and result materialization.
+Prerequisites: Emscripten **3.1.64**, Node 20+, `npm ci` and Playwright Chromium
+under `test/wasm/`. Pin `@duckdb/duckdb-wasm` to a release whose embedded DuckDB
+version matches the extension (currently **v1.5.3**).
 
-### 4. Validate Browser-Specific Rejections
+## Sqllogictest Subset
 
-Keep the negative coverage narrow and user-visible:
+The browser runner supports: `query`, `statement ok|error`, `require`. Unsupported
+directives (`loop`, `foreach`, hash results, multiple connections, etc.) are out
+of scope.
 
-- `auth_mode := 'azure_cli'` fails with a clear unsupported-in-WASM error
-- `auth_mode := 'service_principal'` fails with a clear unsupported-in-WASM error
-- `powerbi://` locators fail at bind time with the documented browser limitation
+Error matching uses substring containment (not full sqllogictest exact match) so
+DuckDB-Wasm worker prefixes like `Invalid Input Error:` do not cause false
+failures.
 
-**Outcome:** CI catches accidental exposure of native-only auth/resolver paths in browser builds.
+## Out of Scope
 
-## Definition of Done
-
-- [x] CI builds `wasm_eh` and `wasm_mvp` green on every push/PR
-- [x] Browser smoke loads the extension in DuckDB-Wasm 1.5.x for `wasm_eh`
-- [x] Browser smoke loads the extension in DuckDB-Wasm 1.5.x for `wasm_mvp`
-- [x] Browser smoke runs `dax_query` successfully against a mock XMLA endpoint for `wasm_eh`
-- [x] Browser smoke runs `dax_query` successfully against a mock XMLA endpoint for `wasm_mvp`
-- [x] Browser smoke verifies the access-token auth header reaches the mock XMLA endpoint for `wasm_eh`
-- [x] Browser smoke verifies the access-token auth header reaches the mock XMLA endpoint for `wasm_mvp`
-- [x] Browser smoke verifies browser auth and locator restrictions for `wasm_eh`
-- [x] `wasm_mvp` negative-message behavior is documented as a DuckDB-Wasm runtime limitation; success-path browser smoke still covers load, registration, HTTP, auth-header propagation, XMLA parsing, and result materialization
-- [x] [docs/wasm.md](wasm.md) reflects the actual toolchain (Emscripten, Node, browser runner, and duckdb-wasm version)
-
-## Suggested Order of Work
-
-1. Push or finish CI/build fixes -> confirm `wasm_eh` and `wasm_mvp` compile
-2. Add the browser smoke harness -> confirm extension `INSTALL` / `LOAD`
-3. Add mock XMLA success assertions -> confirm HTTP and result parsing
-4. Add narrow negative assertions -> confirm native-only paths are rejected
-5. Commit remaining branch cleanup (e.g. `http_client_wasm.cpp` array-literal fix) and update docs
-
-The recommended path is to avoid making Node emulate browser behavior:
-
-| Approach | Tradeoff |
-|----------|----------|
-| **Browser smoke** | Smallest reliable end-to-end signal; matches production runtime |
-| **Node smoke with XHR/worker shims** | Looks lightweight, but validates a hybrid runtime and adds brittle setup |
-| **Async HTTP refactor** | Larger C++ change; useful later, not required to validate this branch |
-
-## Out of Scope (for this plan)
-
-- Live Power BI / Azure token tests in a browser
-- `wasm_threads` platform
-- Large-payload streaming HTTP
-- Multiple-browser matrix
-- Performance benchmarking
-- Community extension publication
+- Live Power BI / Azure tests in CI
+- `wasm_threads`
+- Large-payload streaming HTTP benchmarks
+- Multi-browser matrix
+- Published-catalog verification (pre-deploy CI uses local artifacts only)
 
 ## Related Docs
 
-- [wasm.md](wasm.md) — build, load, auth, and limitations
-- [AGENTS.md](../AGENTS.md) — WASM build and smoke commands
+- [wasm.md](wasm.md) — build, load, auth, CORS, limitations
+- [release_publication.md](release_publication.md) — release checklist including WASM validation

--- a/docs/wasm_testing_plan.md
+++ b/docs/wasm_testing_plan.md
@@ -13,7 +13,7 @@ entry points are in [AGENTS.md](../AGENTS.md).
 | Layer | Harness | What it proves |
 |-------|---------|----------------|
 | **Browser smoke** | `test/wasm/smoke.mjs` | `INSTALL`/`LOAD`, function registration, same-origin mock XMLA HTTP, auth header propagation, XMLA parse/result materialization, and (`wasm_eh` only) native-only path rejection |
-| **Browser sqllogictest** | `test/wasm/run_sqllogictest.mjs` | Offline SQL assertions from `test/sql/pbi_scanner_wasm.test` — validation errors, WASM auth restrictions, `powerbi://` bind rejection — without live Power BI |
+| **Browser sqllogictest** | `test/wasm/run_sqllogictest.mjs` | Offline SQL assertions from `wasm_sql/pbi_scanner_wasm.test` — validation errors, WASM auth restrictions, `powerbi://` bind rejection — without live Power BI |
 
 Both run DuckDB-Wasm inside Chromium via Playwright. Node only serves assets and
 drives the browser; SQL executes in the same runtime shape production uses.
@@ -26,7 +26,10 @@ CORS) lives in `test/wasm/browser_harness.mjs`.
 | File | Runtime | Scope |
 |------|---------|-------|
 | `test/sql/pbi_scanner.test` | Native `unittest` | Full offline validation including `powerbi://` resolver/auth paths |
-| `test/sql/pbi_scanner_wasm.test` | Browser DuckDB-Wasm | WASM-portable cases: direct/loopback XMLA URLs, browser auth limits, earlier `powerbi://` bind failure |
+| `wasm_sql/pbi_scanner_wasm.test` | Browser DuckDB-Wasm | WASM-portable cases: direct/loopback XMLA URLs, browser auth limits, earlier `powerbi://` bind failure |
+
+WASM sqllogictest files are kept outside `test/` because DuckDB's native
+`unittest` recursively registers every `test/**/*.test` file.
 
 Do not run the native file unmodified against WASM — several `powerbi://`
 records reach different validation stages on native vs browser.

--- a/scripts/patch_fmt_vs2026.py
+++ b/scripts/patch_fmt_vs2026.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Remove fmt stdext::checked_array_iterator usage for Visual Studio 2026."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+FMT_SECURE_SCL_BLOCK = """#ifdef _SECURE_SCL
+// Make a checked iterator to avoid MSVC warnings.
+template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+template <typename T> checked_ptr<T> make_checked(T* p, std::size_t size) {
+  return {p, size};
+}
+#else
+template <typename T> using checked_ptr = T*;
+template <typename T> inline T* make_checked(T* p, std::size_t) { return p; }
+#endif"""
+
+FMT_SECURE_SCL_REPLACEMENT = """template <typename T> using checked_ptr = T*;
+template <typename T> inline T* make_checked(T* p, std::size_t) { return p; }"""
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <path/to/fmt/format.h>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    text = path.read_text(encoding="utf-8")
+    if FMT_SECURE_SCL_BLOCK not in text:
+        if FMT_SECURE_SCL_REPLACEMENT in text:
+            return 0
+        print(f"fmt patch pattern not found in {path}", file=sys.stderr)
+        return 1
+
+    path.write_text(text.replace(FMT_SECURE_SCL_BLOCK, FMT_SECURE_SCL_REPLACEMENT), encoding="utf-8")
+    print(f"Patched {path} for Visual Studio 2026")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/patch_fmt_vs2026.py
+++ b/scripts/patch_fmt_vs2026.py
@@ -31,6 +31,9 @@ def main() -> int:
     if FMT_SECURE_SCL_BLOCK not in text:
         if FMT_SECURE_SCL_REPLACEMENT in text:
             return 0
+        if "stdext::checked_array_iterator" not in text:
+            # DuckDB main (and other upstream bumps) may already ship a VS 2026-safe fmt.
+            return 0
         print(f"fmt patch pattern not found in {path}", file=sys.stderr)
         return 1
 

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -2,6 +2,7 @@
 
 #include "connection_string.hpp"
 #include "http_client.hpp"
+#include "pbi_duckdb_compat.hpp"
 #include "pbi_platform.hpp"
 #include "pbi_scanner_util.hpp"
 
@@ -217,7 +218,7 @@ static string UrlEncode(const string &value) {
 }
 
 static string GetOptionalSecretValue(const KeyValueSecret &secret,
-                                     const string &key) {
+                                     const char *key) {
   Value value;
   if (!secret.TryGetValue(key, value) || value.IsNull()) {
     return string();
@@ -602,7 +603,8 @@ static string ResolveSecretBackedAccessToken(ClientContext &context,
   }
 
   auto &base_secret = *secret_entry->secret;
-  if (!StringUtil::CIEquals(base_secret.GetType(), "azure")) {
+  if (!StringUtil::CIEquals(
+          pbi_compat::IdentifierName(base_secret.GetType()), "azure")) {
     throw InvalidInputException("Secret \"%s\" must be TYPE azure",
                                 secret_name);
   }
@@ -614,7 +616,8 @@ static string ResolveSecretBackedAccessToken(ClientContext &context,
                                 secret_name);
   }
 
-  auto provider = StringUtil::Lower(Trimmed(base_secret.GetProvider()));
+  auto provider = StringUtil::Lower(
+      Trimmed(pbi_compat::IdentifierName(base_secret.GetProvider())));
   if (provider == "credential_chain") {
     return ResolveCredentialChainSecret(*key_value_secret, secret_name);
   }

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -603,8 +603,8 @@ static string ResolveSecretBackedAccessToken(ClientContext &context,
   }
 
   auto &base_secret = *secret_entry->secret;
-  if (!StringUtil::CIEquals(
-          pbi_compat::IdentifierName(base_secret.GetType()), "azure")) {
+  if (!StringUtil::CIEquals(pbi_compat::IdentifierName(base_secret.GetType()),
+                            "azure")) {
     throw InvalidInputException("Secret \"%s\" must be TYPE azure",
                                 secret_name);
   }

--- a/src/dax_query.cpp
+++ b/src/dax_query.cpp
@@ -727,7 +727,7 @@ TableFunction CreateDaxQueryFunction() {
 
 static TableFunction CreateFixedDaxFunction(const string &name,
                                             const string &dax_text) {
-  TableFunction function(name, {LogicalType::VARCHAR}, DaxQueryExecute,
+  TableFunction function(name.c_str(), {LogicalType::VARCHAR}, DaxQueryExecute,
                          DaxQueryBind, DaxQueryInit);
   function.extra_info = dax_text;
   RegisterCommonDaxNamedParameters(function);

--- a/src/include/pbi_duckdb_compat.hpp
+++ b/src/include/pbi_duckdb_compat.hpp
@@ -15,7 +15,8 @@ namespace duckdb {
 namespace pbi_compat {
 
 inline named_parameter_map_t::const_iterator
-FindNamedParameter(const named_parameter_map_t &named_parameters, const char *name) {
+FindNamedParameter(const named_parameter_map_t &named_parameters,
+                   const char *name) {
   return named_parameters.find(name);
 }
 
@@ -24,9 +25,7 @@ inline string IdentifierName(const Identifier &identifier) {
   return identifier.GetIdentifierName();
 }
 #else
-inline const string &IdentifierName(const string &value) {
-  return value;
-}
+inline const string &IdentifierName(const string &value) { return value; }
 #endif
 
 } // namespace pbi_compat

--- a/src/include/pbi_duckdb_compat.hpp
+++ b/src/include/pbi_duckdb_compat.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "duckdb/common/named_parameter_map.hpp"
+#include "duckdb/common/string.hpp"
+
+#if defined(__has_include)
+#if __has_include("duckdb/common/identifier.hpp")
+#include "duckdb/common/identifier.hpp"
+#define PBI_HAS_DUCKDB_IDENTIFIER 1
+#endif
+#endif
+
+namespace duckdb {
+
+namespace pbi_compat {
+
+inline named_parameter_map_t::const_iterator
+FindNamedParameter(const named_parameter_map_t &named_parameters, const char *name) {
+  return named_parameters.find(name);
+}
+
+#ifdef PBI_HAS_DUCKDB_IDENTIFIER
+inline string IdentifierName(const Identifier &identifier) {
+  return identifier.GetIdentifierName();
+}
+#else
+inline const string &IdentifierName(const string &value) {
+  return value;
+}
+#endif
+
+} // namespace pbi_compat
+
+} // namespace duckdb

--- a/src/include/pbi_scanner_util.hpp
+++ b/src/include/pbi_scanner_util.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pbi_duckdb_compat.hpp"
+
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/function.hpp"
@@ -20,15 +22,15 @@ inline string Trimmed(const string &value) {
 
 inline bool
 HasNonNullNamedParameter(const named_parameter_map_t &named_parameters,
-                         const string &name) {
-  auto entry = named_parameters.find(name);
+                         const char *name) {
+  auto entry = pbi_compat::FindNamedParameter(named_parameters, name);
   return entry != named_parameters.end() && !entry->second.IsNull();
 }
 
 inline string
 GetOptionalNamedParameter(const named_parameter_map_t &named_parameters,
-                          const string &name) {
-  auto entry = named_parameters.find(name);
+                          const char *name) {
+  auto entry = pbi_compat::FindNamedParameter(named_parameters, name);
   if (entry == named_parameters.end() || entry->second.IsNull()) {
     return string();
   }

--- a/test/sql/pbi_scanner_wasm.test
+++ b/test/sql/pbi_scanner_wasm.test
@@ -1,0 +1,144 @@
+# name: test/sql/pbi_scanner_wasm.test
+# description: pbi_scanner validation for DuckDB-Wasm
+# group: [sql]
+
+query I
+SELECT count(*)
+FROM duckdb_functions()
+WHERE function_name = 'dax_query';
+----
+0
+
+require pbi_scanner
+
+query I
+SELECT count(*)
+FROM duckdb_functions()
+WHERE function_name = 'dax_query';
+----
+1
+
+query I
+SELECT count(*)
+FROM duckdb_functions()
+WHERE function_name IN ('pbi_tables', 'pbi_columns', 'pbi_measures', 'pbi_relationships');
+----
+4
+
+query I
+SELECT count(*)
+FROM duckdb_functions()
+WHERE function_name LIKE '__pbi_scanner_test_%';
+----
+0
+
+statement error
+SELECT *
+FROM dax_query(
+    'Initial Catalog=example_semantic_model;',
+    'EVALUATE ROW("x", 1)'
+);
+----
+Data Source is required
+
+statement error
+SELECT *
+FROM dax_query(
+    '',
+    'EVALUATE ROW("x", 1)'
+);
+----
+connection_string is required
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=powerbi://api.powerbi.com/v1.0/myorg/Example%20Workspace;Initial Catalog=example_semantic_model;',
+    'EVALUATE ROW("x", 1)'
+);
+----
+powerbi:// locators are not supported directly in DuckDB-Wasm
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=http://127.0.0.1:9999/xmla;Initial Catalog=mock;',
+    ''
+);
+----
+dax_text is required
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=https://example.com/xmla?vs=sobe_wowvirtualserver&db=example_db;Initial Catalog=sobe_wowvirtualserver-example_db;',
+    'EVALUATE ROW("x", 1)',
+    access_token := 'dummy',
+    timeout_ms := 0
+);
+----
+timeout_ms must be greater than zero
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=https://example.com/xmla?vs=sobe_wowvirtualserver&db=example_db;Initial Catalog=sobe_wowvirtualserver-example_db;',
+    'EVALUATE ROW("x", 1)',
+    access_token := 'dummy',
+    schema_probe_rows := -1
+);
+----
+schema_probe_rows must be zero or greater
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=https://example.com/xmla?vs=sobe_wowvirtualserver&db=example_db;Initial Catalog=sobe_wowvirtualserver-example_db;',
+    'EVALUATE ROW("x", 1)'
+);
+----
+access_token named parameter or PBI_XMLA_ACCESS_TOKEN environment variable is required
+
+statement ok
+SET pbi_scanner_auth_mode='azure_cli';
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=https://example.com/xmla?vs=sobe_wowvirtualserver&db=example_db;Initial Catalog=sobe_wowvirtualserver-example_db;',
+    'EVALUATE ROW("x", 1)',
+    auth_mode := 'unsupported_mode'
+);
+----
+unsupported auth_mode "unsupported_mode"
+
+statement ok
+SET pbi_scanner_auth_mode='';
+
+statement error
+SET pbi_scanner_auth_mode='unsupported_mode';
+----
+unsupported auth_mode "unsupported_mode"
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=http://127.0.0.1:9999/xmla;Initial Catalog=mock;',
+    'EVALUATE ROW("x", 1)',
+    auth_mode := 'azure_cli'
+);
+----
+azure_cli auth is not supported in DuckDB-Wasm
+
+statement error
+SELECT *
+FROM dax_query(
+    'Data Source=http://127.0.0.1:9999/xmla;Initial Catalog=mock;',
+    'EVALUATE ROW("x", 1)',
+    auth_mode := 'service_principal',
+    tenant_id := 'tenant',
+    client_id := 'client',
+    client_secret := 'secret'
+);
+----
+service_principal auth is not supported in browser DuckDB-Wasm

--- a/test/sql/pbi_scanner_wasm.test
+++ b/test/sql/pbi_scanner_wasm.test
@@ -1,5 +1,8 @@
 # name: test/sql/pbi_scanner_wasm.test
 # description: pbi_scanner validation for DuckDB-Wasm
+# Native offline assertions live in test/sql/pbi_scanner.test.
+# This file holds WASM-specific expectations (direct XMLA URLs, powerbi:// bind
+# rejection, browser auth restrictions). Run via test/wasm/run_pbi_wasm_sqllogictest.py.
 # group: [sql]
 
 query I

--- a/test/sql/pbi_scanner_wasm.test
+++ b/test/sql/pbi_scanner_wasm.test
@@ -1,9 +1,10 @@
 # name: test/sql/pbi_scanner_wasm.test
 # description: pbi_scanner validation for DuckDB-Wasm
+# group: [sql]
+
 # Native offline assertions live in test/sql/pbi_scanner.test.
 # This file holds WASM-specific expectations (direct XMLA URLs, powerbi:// bind
 # rejection, browser auth restrictions). Run via test/wasm/run_pbi_wasm_sqllogictest.py.
-# group: [sql]
 
 query I
 SELECT count(*)

--- a/test/wasm/browser_harness.mjs
+++ b/test/wasm/browser_harness.mjs
@@ -1,0 +1,275 @@
+import { createServer } from "node:http";
+import { dirname, extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { chromium } from "playwright";
+
+const require = createRequire(import.meta.url);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export const xmlaResponse = `<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:schema>
+      <xsd:complexType name="row">
+        <xsd:sequence>
+          <xsd:element name="probe_ok" type="xsd:int" />
+        </xsd:sequence>
+      </xsd:complexType>
+    </xsd:schema>
+  </schema>
+  <row><probe_ok>1</probe_ok></row>
+</root>`;
+
+export function getRepoRoot() {
+  return repoRoot;
+}
+
+export function getExtensionPath() {
+  return resolve(
+    repoRoot,
+    process.env.PBI_WASM_EXTENSION_PATH ||
+      "build/wasm_eh/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm",
+  );
+}
+
+export function bundleKeyForPlatform() {
+  const platform = process.env.PBI_WASM_DUCKDB_PLATFORM;
+  if (platform === "wasm_mvp") {
+    return "mvp";
+  }
+  if (platform === "wasm_eh" || !platform) {
+    return "eh";
+  }
+  throw new Error(`unsupported PBI_WASM_DUCKDB_PLATFORM: ${platform}`);
+}
+
+export function corsHeaders(extra = {}) {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers":
+      "Authorization, Content-Type, X-Transport-Caps-Negotiation-Flags, X-AS-ActivityID, X-AS-SessionID, X-AS-Get-Next, X-PowerBI-ResourceKey",
+    "Access-Control-Allow-Private-Network": "true",
+    "Access-Control-Expose-Headers": "*",
+    ...extra,
+  };
+}
+
+function contentType(path) {
+  switch (extname(path)) {
+    case ".html":
+      return "text/html";
+    case ".js":
+    case ".mjs":
+      return "text/javascript";
+    case ".wasm":
+      return "application/wasm";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function listen(server) {
+  return new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen(server.address().port);
+    });
+  });
+}
+
+export function patchDuckDbMvpWorker(source) {
+  if (!source.includes("_setThrew") || source.includes("function _setThrew(")) {
+    return source;
+  }
+  const marker = "Module._setTempRet0=_setTempRet0;";
+  const patch =
+    "var __pbiScannerThrew=0,__pbiScannerThrewValue=0;" +
+    "function _setThrew(threw,value){" +
+    "if(threw){if(!__pbiScannerThrew){__pbiScannerThrew=threw;__pbiScannerThrewValue=value;}}" +
+    "else{__pbiScannerThrew=0;__pbiScannerThrewValue=value;}" +
+    "}" +
+    "Module._setThrew=_setThrew;";
+  if (!source.includes(marker)) {
+    return patch + source;
+  }
+  return source.replace(marker, marker + patch);
+}
+
+export async function startBrowserAssetServer({ pageTitle, pageModuleScript }) {
+  const extensionPath = getExtensionPath();
+  const duckdbDist = dirname(require.resolve("@duckdb/duckdb-wasm"));
+  const arrowDist = dirname(require.resolve("apache-arrow"));
+  const flatbuffersDist = dirname(dirname(require.resolve("flatbuffers")));
+  const tslibDist = dirname(require.resolve("tslib"));
+  const artifact = readFileSync(extensionPath);
+  const extensionRequests = [];
+  const xmlaRequests = [];
+  const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>${pageTitle}</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "apache-arrow": "/apache-arrow/Arrow.dom.mjs",
+          "flatbuffers": "/flatbuffers/mjs/flatbuffers.js",
+          "tslib": "/tslib/tslib.es6.mjs"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <script type="module">
+${pageModuleScript}
+    </script>
+  </body>
+</html>`;
+
+  const server = createServer((req, res) => {
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, corsHeaders());
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url, "http://127.0.0.1");
+    if (url.pathname === "/") {
+      res.writeHead(200, corsHeaders({ "Content-Type": "text/html" }));
+      res.end(html);
+      return;
+    }
+
+    if (url.pathname === "/xmla") {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        xmlaRequests.push({
+          method: req.method,
+          url: req.url,
+          authorization: req.headers.authorization || "",
+          headers: req.headers,
+          body,
+        });
+        res.writeHead(
+          200,
+          corsHeaders({
+            "Content-Type": "text/xml",
+            "X-Transport-Caps-Negotiation-Flags": "0,0,0,0,0",
+          }),
+        );
+        res.end(xmlaResponse);
+      });
+      return;
+    }
+
+    if (url.pathname.startsWith("/duckdb/")) {
+      const fileName = url.pathname.slice("/duckdb/".length);
+      const filePath = resolve(duckdbDist, fileName);
+      if (!filePath.startsWith(duckdbDist)) {
+        res.writeHead(403, corsHeaders());
+        res.end("forbidden");
+        return;
+      }
+      try {
+        if (url.pathname.endsWith("duckdb-browser-mvp.worker.js")) {
+          res.writeHead(200, corsHeaders({ "Content-Type": "text/javascript" }));
+          res.end(patchDuckDbMvpWorker(readFileSync(filePath, "utf8")));
+          return;
+        }
+        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
+        res.end(readFileSync(filePath));
+      } catch {
+        res.writeHead(404, corsHeaders());
+        res.end("not found");
+      }
+      return;
+    }
+
+    if (url.pathname.startsWith("/apache-arrow/")) {
+      const fileName = url.pathname.slice("/apache-arrow/".length);
+      const filePath = resolve(arrowDist, fileName);
+      if (!filePath.startsWith(arrowDist)) {
+        res.writeHead(403, corsHeaders());
+        res.end("forbidden");
+        return;
+      }
+      try {
+        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
+        res.end(readFileSync(filePath));
+      } catch {
+        res.writeHead(404, corsHeaders());
+        res.end("not found");
+      }
+      return;
+    }
+
+    if (url.pathname.startsWith("/tslib/")) {
+      const fileName = url.pathname.slice("/tslib/".length);
+      const filePath = resolve(tslibDist, fileName);
+      if (!filePath.startsWith(tslibDist)) {
+        res.writeHead(403, corsHeaders());
+        res.end("forbidden");
+        return;
+      }
+      try {
+        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
+        res.end(readFileSync(filePath));
+      } catch {
+        res.writeHead(404, corsHeaders());
+        res.end("not found");
+      }
+      return;
+    }
+
+    if (url.pathname.startsWith("/flatbuffers/")) {
+      const fileName = url.pathname.slice("/flatbuffers/".length);
+      const filePath = resolve(flatbuffersDist, fileName);
+      if (!filePath.startsWith(flatbuffersDist)) {
+        res.writeHead(403, corsHeaders());
+        res.end("forbidden");
+        return;
+      }
+      try {
+        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
+        res.end(readFileSync(filePath));
+      } catch {
+        res.writeHead(404, corsHeaders());
+        res.end("not found");
+      }
+      return;
+    }
+
+    if (url.pathname.endsWith("pbi_scanner.duckdb_extension.wasm")) {
+      extensionRequests.push(url.pathname);
+      res.writeHead(200, corsHeaders({ "Content-Type": "application/wasm" }));
+      res.end(artifact);
+      return;
+    }
+
+    res.writeHead(404, corsHeaders());
+    res.end("not found");
+  });
+  const port = await listen(server);
+  return { server, extensionRequests, xmlaRequests, url: `http://127.0.0.1:${port}` };
+}
+
+export async function withBrowserPage(assetServer, fn) {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    page.on("console", (message) => console.log(`[browser:${message.type()}] ${message.text()}`));
+    page.on("pageerror", (error) => console.error(`[browser:error] ${error.message}`));
+    await page.goto(assetServer.url, { waitUntil: "load" });
+    return await fn(page);
+  } finally {
+    await browser.close();
+  }
+}

--- a/test/wasm/package.json
+++ b/test/wasm/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "live:pbi": "node live_pbi.mjs",
-    "smoke": "node smoke.mjs"
+    "smoke": "node smoke.mjs",
+    "sqllogictest": "node run_sqllogictest.mjs"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.33.1-dev55.0",

--- a/test/wasm/run_pbi_wasm_sqllogictest.py
+++ b/test/wasm/run_pbi_wasm_sqllogictest.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WASM_TEST_DIR = REPO_ROOT / "test" / "wasm"
+DEFAULT_TEST = REPO_ROOT / "test" / "sql" / "pbi_scanner_wasm.test"
+
+
+def default_extension(platform: str) -> Path:
+    return (
+        REPO_ROOT
+        / "build"
+        / platform
+        / "extension"
+        / "pbi_scanner"
+        / "pbi_scanner.duckdb_extension.wasm"
+    )
+
+
+def run(command, cwd=REPO_ROOT, env=None):
+    print("+ " + " ".join(str(part) for part in command), flush=True)
+    subprocess.run(command, cwd=cwd, env=env, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run pbi_scanner sqllogictest files against DuckDB-Wasm in a browser"
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="build the selected DuckDB WASM platform before running sqllogictest",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["wasm_eh", "wasm_mvp"],
+        default="wasm_eh",
+        help="DuckDB WASM platform directory under build/",
+    )
+    parser.add_argument(
+        "--extension",
+        type=Path,
+        default=None,
+        help="path to pbi_scanner.duckdb_extension.wasm",
+    )
+    parser.add_argument(
+        "--test",
+        type=Path,
+        action="append",
+        default=None,
+        help="sqllogictest file to run (default: test/sql/pbi_scanner_wasm.test)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="print per-record sqllogictest results",
+    )
+    args = parser.parse_args()
+
+    if args.build:
+        run(["make", args.platform])
+
+    extension = (args.extension or default_extension(args.platform)).resolve()
+    if not extension.exists():
+        raise SystemExit(
+            f"Missing WASM extension artifact: {extension}\n"
+            f"Run this command again with --build, or build it with `make {args.platform}` first."
+        )
+
+    if not (WASM_TEST_DIR / "node_modules").exists():
+        run(["npm", "ci"], cwd=WASM_TEST_DIR)
+
+    env = os.environ.copy()
+    env["PBI_WASM_EXTENSION_PATH"] = str(extension)
+    env["PBI_WASM_DUCKDB_PLATFORM"] = args.platform
+
+    command = ["node", "run_sqllogictest.mjs"]
+    for test_path in args.test or [DEFAULT_TEST]:
+        command.extend(["--test", str(test_path.resolve())])
+    if args.verbose:
+        command.append("--verbose")
+    run(command, cwd=WASM_TEST_DIR, env=env)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.returncode)

--- a/test/wasm/run_pbi_wasm_sqllogictest.py
+++ b/test/wasm/run_pbi_wasm_sqllogictest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WASM_TEST_DIR = REPO_ROOT / "test" / "wasm"
-DEFAULT_TEST = REPO_ROOT / "test" / "sql" / "pbi_scanner_wasm.test"
+DEFAULT_TEST = REPO_ROOT / "wasm_sql" / "pbi_scanner_wasm.test"
 
 
 def default_extension(platform: str) -> Path:
@@ -52,7 +52,7 @@ def main():
         type=Path,
         action="append",
         default=None,
-        help="sqllogictest file to run (default: test/sql/pbi_scanner_wasm.test)",
+        help="sqllogictest file to run (default: wasm_sql/pbi_scanner_wasm.test)",
     )
     parser.add_argument(
         "--verbose",

--- a/test/wasm/run_sqllogictest.mjs
+++ b/test/wasm/run_sqllogictest.mjs
@@ -29,7 +29,7 @@ function parseArgs(argv) {
     throw new Error(`unknown argument: ${arg}`);
   }
   if (!options.tests.length) {
-    options.tests.push(resolve(getRepoRoot(), "test/sql/pbi_scanner_wasm.test"));
+    options.tests.push(resolve(getRepoRoot(), "wasm_sql/pbi_scanner_wasm.test"));
   }
   return options;
 }

--- a/test/wasm/run_sqllogictest.mjs
+++ b/test/wasm/run_sqllogictest.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  bundleKeyForPlatform,
+  getExtensionPath,
+  getRepoRoot,
+  startBrowserAssetServer,
+  withBrowserPage,
+} from "./browser_harness.mjs";
+import { parseSqllogictest } from "./sqllogictest_parser.mjs";
+import { sqllogictestBrowserModuleScript } from "./sqllogictest_browser.mjs";
+
+function parseArgs(argv) {
+  const options = {
+    tests: [],
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--test") {
+      options.tests.push(resolve(argv[++i]));
+      continue;
+    }
+    if (arg === "--verbose") {
+      options.verbose = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!options.tests.length) {
+    options.tests.push(resolve(getRepoRoot(), "test/sql/pbi_scanner_wasm.test"));
+  }
+  return options;
+}
+
+function describeRecord(record) {
+  if (record.type === "require") {
+    return `require ${record.extension}`;
+  }
+  if (record.type === "query") {
+    return `query ${record.types}`;
+  }
+  return `statement ${record.mode}`;
+}
+
+function summarizeFailures(fileName, results) {
+  const failures = results.filter((result) => result.status === "fail");
+  if (!failures.length) {
+    return;
+  }
+  console.error(`\n${fileName} failures:`);
+  for (const failure of failures) {
+    console.error(`  [${failure.index + 1}] ${describeRecord(failure.record)}`);
+    console.error(`      ${failure.message}`);
+  }
+}
+
+async function runTestFile(testPath, options) {
+  const content = readFileSync(testPath, "utf8");
+  const parsed = parseSqllogictest(content, testPath);
+  const platform = process.env.PBI_WASM_DUCKDB_PLATFORM || "wasm_eh";
+  const skipStatementErrors = platform === "wasm_mvp";
+
+  const assetServer = await startBrowserAssetServer({
+    pageTitle: "pbi_scanner wasm sqllogictest",
+    pageModuleScript: sqllogictestBrowserModuleScript(),
+  });
+
+  try {
+    const results = await withBrowserPage(assetServer, async (page) => {
+      await page.waitForFunction(() => typeof window.runSqllogictestFile === "function");
+      return page.evaluate(
+        ({ bundleKey, extensionRepository, records, skipStatementErrors }) =>
+          window.runSqllogictestFile({
+            bundleKey,
+            extensionRepository,
+            records,
+            skipStatementErrors,
+          }),
+        {
+          bundleKey: bundleKeyForPlatform(),
+          extensionRepository: assetServer.url,
+          records: parsed.records,
+          skipStatementErrors,
+        },
+      );
+    });
+
+    const passed = results.filter((result) => result.status === "pass").length;
+    const failed = results.filter((result) => result.status === "fail").length;
+    const skipped = results.filter((result) => result.status === "skip").length;
+
+    if (options.verbose) {
+      for (const result of results) {
+        console.log(
+          `[${result.status}] ${describeRecord(result.record)}${
+            result.message ? `: ${result.message}` : ""
+          }`,
+        );
+      }
+    }
+
+    if (failed > 0) {
+      summarizeFailures(testPath, results);
+      throw new Error(`${testPath}: ${failed} failed, ${passed} passed, ${skipped} skipped`);
+    }
+
+    console.log(
+      `pbi_scanner WASM sqllogictest passed (${testPath}, platform=${platform}, records=${passed} passed, ${skipped} skipped)`,
+    );
+    return { passed, failed, skipped };
+  } finally {
+    assetServer.server.close();
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (!getExtensionPath()) {
+    throw new Error("extension path is required");
+  }
+
+  let totalPassed = 0;
+  let totalSkipped = 0;
+  for (const testPath of options.tests) {
+    const summary = await runTestFile(testPath, options);
+    totalPassed += summary.passed;
+    totalSkipped += summary.skipped;
+  }
+
+  const platform = process.env.PBI_WASM_DUCKDB_PLATFORM || "wasm_eh";
+  console.log(
+    `pbi_scanner WASM sqllogictest suite passed (platform=${platform}, records=${totalPassed} passed, ${totalSkipped} skipped)`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});

--- a/test/wasm/smoke.mjs
+++ b/test/wasm/smoke.mjs
@@ -1,111 +1,10 @@
-import { createServer } from "node:http";
-import { dirname, extname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { chromium } from "playwright";
+import {
+  bundleKeyForPlatform,
+  startBrowserAssetServer,
+  withBrowserPage,
+} from "./browser_harness.mjs";
 
-const require = createRequire(import.meta.url);
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const extensionPath = resolve(
-  repoRoot,
-  process.env.PBI_WASM_EXTENSION_PATH ||
-    "build/wasm_eh/extension/pbi_scanner/pbi_scanner.duckdb_extension.wasm",
-);
-
-const xmlaResponse = `<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:schema>
-      <xsd:complexType name="row">
-        <xsd:sequence>
-          <xsd:element name="probe_ok" type="xsd:int" />
-        </xsd:sequence>
-      </xsd:complexType>
-    </xsd:schema>
-  </schema>
-  <row><probe_ok>1</probe_ok></row>
-</root>`;
-
-function corsHeaders(extra = {}) {
-  return {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers":
-      "Authorization, Content-Type, X-Transport-Caps-Negotiation-Flags, X-AS-ActivityID, X-AS-SessionID, X-AS-Get-Next, X-PowerBI-ResourceKey",
-    "Access-Control-Allow-Private-Network": "true",
-    "Access-Control-Expose-Headers": "*",
-    ...extra,
-  };
-}
-
-function contentType(path) {
-  switch (extname(path)) {
-    case ".html":
-      return "text/html";
-    case ".js":
-    case ".mjs":
-      return "text/javascript";
-    case ".wasm":
-      return "application/wasm";
-    default:
-      return "application/octet-stream";
-  }
-}
-
-function listen(server) {
-  return new Promise((resolveListen, rejectListen) => {
-    server.once("error", rejectListen);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", rejectListen);
-      resolveListen(server.address().port);
-    });
-  });
-}
-
-function patchDuckDbMvpWorker(source) {
-  if (!source.includes("_setThrew") || source.includes("function _setThrew(")) {
-    return source;
-  }
-  const marker = "Module._setTempRet0=_setTempRet0;";
-  const patch =
-    "var __pbiScannerThrew=0,__pbiScannerThrewValue=0;" +
-    "function _setThrew(threw,value){" +
-    "if(threw){if(!__pbiScannerThrew){__pbiScannerThrew=threw;__pbiScannerThrewValue=value;}}" +
-    "else{__pbiScannerThrew=0;__pbiScannerThrewValue=value;}" +
-    "}" +
-    "Module._setThrew=_setThrew;";
-  if (!source.includes(marker)) {
-    return patch + source;
-  }
-  return source.replace(marker, marker + patch);
-}
-
-async function startBrowserAssetServer() {
-  const duckdbDist = dirname(require.resolve("@duckdb/duckdb-wasm"));
-  const arrowDist = dirname(require.resolve("apache-arrow"));
-  const flatbuffersDist = dirname(dirname(require.resolve("flatbuffers")));
-  const tslibDist = dirname(require.resolve("tslib"));
-  const artifact = readFileSync(extensionPath);
-  const extensionRequests = [];
-  const xmlaRequests = [];
-  const html = `<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>pbi_scanner wasm smoke</title>
-    <script type="importmap">
-      {
-        "imports": {
-          "apache-arrow": "/apache-arrow/Arrow.dom.mjs",
-          "flatbuffers": "/flatbuffers/mjs/flatbuffers.js",
-          "tslib": "/tslib/tslib.es6.mjs"
-        }
-      }
-    </script>
-  </head>
-  <body>
-    <script type="module">
+const smokePageModuleScript = `
       import * as duckdb from "/duckdb/duckdb-browser.mjs";
 
       async function expectQueryError(conn, sql, expectedSubstring, label) {
@@ -239,173 +138,27 @@ async function startBrowserAssetServer() {
           worker.terminate();
         }
       };
-    </script>
-  </body>
-</html>`;
-
-  const server = createServer((req, res) => {
-    if (req.method === "OPTIONS") {
-      res.writeHead(204, corsHeaders());
-      res.end();
-      return;
-    }
-
-    const url = new URL(req.url, "http://127.0.0.1");
-    if (url.pathname === "/") {
-      res.writeHead(200, corsHeaders({ "Content-Type": "text/html" }));
-      res.end(html);
-      return;
-    }
-
-    if (url.pathname === "/xmla") {
-      let body = "";
-      req.setEncoding("utf8");
-      req.on("data", (chunk) => {
-        body += chunk;
-      });
-      req.on("end", () => {
-        xmlaRequests.push({
-          method: req.method,
-          url: req.url,
-          authorization: req.headers.authorization || "",
-          headers: req.headers,
-          body,
-        });
-        res.writeHead(
-          200,
-          corsHeaders({
-            "Content-Type": "text/xml",
-            "X-Transport-Caps-Negotiation-Flags": "0,0,0,0,0",
-          }),
-        );
-        res.end(xmlaResponse);
-      });
-      return;
-    }
-
-    if (url.pathname.startsWith("/duckdb/")) {
-      const fileName = url.pathname.slice("/duckdb/".length);
-      const filePath = resolve(duckdbDist, fileName);
-      if (!filePath.startsWith(duckdbDist)) {
-        res.writeHead(403, corsHeaders());
-        res.end("forbidden");
-        return;
-      }
-      try {
-        if (url.pathname.endsWith("duckdb-browser-mvp.worker.js")) {
-          res.writeHead(200, corsHeaders({ "Content-Type": "text/javascript" }));
-          res.end(patchDuckDbMvpWorker(readFileSync(filePath, "utf8")));
-          return;
-        }
-        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
-        res.end(readFileSync(filePath));
-      } catch {
-        res.writeHead(404, corsHeaders());
-        res.end("not found");
-      }
-      return;
-    }
-
-    if (url.pathname.startsWith("/apache-arrow/")) {
-      const fileName = url.pathname.slice("/apache-arrow/".length);
-      const filePath = resolve(arrowDist, fileName);
-      if (!filePath.startsWith(arrowDist)) {
-        res.writeHead(403, corsHeaders());
-        res.end("forbidden");
-        return;
-      }
-      try {
-        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
-        res.end(readFileSync(filePath));
-      } catch {
-        res.writeHead(404, corsHeaders());
-        res.end("not found");
-      }
-      return;
-    }
-
-    if (url.pathname.startsWith("/tslib/")) {
-      const fileName = url.pathname.slice("/tslib/".length);
-      const filePath = resolve(tslibDist, fileName);
-      if (!filePath.startsWith(tslibDist)) {
-        res.writeHead(403, corsHeaders());
-        res.end("forbidden");
-        return;
-      }
-      try {
-        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
-        res.end(readFileSync(filePath));
-      } catch {
-        res.writeHead(404, corsHeaders());
-        res.end("not found");
-      }
-      return;
-    }
-
-    if (url.pathname.startsWith("/flatbuffers/")) {
-      const fileName = url.pathname.slice("/flatbuffers/".length);
-      const filePath = resolve(flatbuffersDist, fileName);
-      if (!filePath.startsWith(flatbuffersDist)) {
-        res.writeHead(403, corsHeaders());
-        res.end("forbidden");
-        return;
-      }
-      try {
-        res.writeHead(200, corsHeaders({ "Content-Type": contentType(filePath) }));
-        res.end(readFileSync(filePath));
-      } catch {
-        res.writeHead(404, corsHeaders());
-        res.end("not found");
-      }
-      return;
-    }
-
-    if (url.pathname.endsWith("pbi_scanner.duckdb_extension.wasm")) {
-      extensionRequests.push(url.pathname);
-      res.writeHead(200, corsHeaders({ "Content-Type": "application/wasm" }));
-      res.end(artifact);
-      return;
-    }
-
-    res.writeHead(404, corsHeaders());
-    res.end("not found");
-  });
-  const port = await listen(server);
-  return { server, extensionRequests, xmlaRequests, url: `http://127.0.0.1:${port}` };
-}
-
-function bundleKeyForPlatform() {
-  const platform = process.env.PBI_WASM_DUCKDB_PLATFORM;
-  if (platform === "wasm_mvp") {
-    return "mvp";
-  }
-  if (platform === "wasm_eh" || !platform) {
-    return "eh";
-  }
-  throw new Error(`unsupported PBI_WASM_DUCKDB_PLATFORM: ${platform}`);
-}
+`;
 
 async function main() {
-  const assetServer = await startBrowserAssetServer();
-  let browser;
+  const assetServer = await startBrowserAssetServer({
+    pageTitle: "pbi_scanner wasm smoke",
+    pageModuleScript: smokePageModuleScript,
+  });
 
   try {
-    browser = await chromium.launch();
-    const page = await browser.newPage();
-    page.on("console", (message) => console.log(`[browser:${message.type()}] ${message.text()}`));
-    page.on("pageerror", (error) => console.error(`[browser:error] ${error.message}`));
-    await page.goto(assetServer.url, { waitUntil: "load" });
-    await page.waitForFunction(() => typeof window.runPbiSmoke === "function");
-
-    const smokeResult = await page.evaluate(
-      ({ bundleKey, extensionRepository, xmlaUrl }) =>
-        window.runPbiSmoke({ bundleKey, extensionRepository, xmlaUrl }),
-      {
-        bundleKey: bundleKeyForPlatform(),
-        extensionRepository: assetServer.url,
-        xmlaUrl: `${assetServer.url}/xmla`,
-      },
-    );
+    const smokeResult = await withBrowserPage(assetServer, async (page) => {
+      await page.waitForFunction(() => typeof window.runPbiSmoke === "function");
+      return page.evaluate(
+        ({ bundleKey, extensionRepository, xmlaUrl }) =>
+          window.runPbiSmoke({ bundleKey, extensionRepository, xmlaUrl }),
+        {
+          bundleKey: bundleKeyForPlatform(),
+          extensionRepository: assetServer.url,
+          xmlaUrl: `${assetServer.url}/xmla`,
+        },
+      );
+    });
 
     if (!assetServer.xmlaRequests.some((request) => request.authorization === "Bearer mock-token")) {
       throw new Error("mock server did not observe expected Authorization header");
@@ -428,9 +181,6 @@ async function main() {
       );
     } else {
       console.log("xmla requests: <none>");
-    }
-    if (browser) {
-      await browser.close();
     }
     assetServer.server.close();
   }

--- a/test/wasm/sqllogictest_browser.mjs
+++ b/test/wasm/sqllogictest_browser.mjs
@@ -1,0 +1,163 @@
+export function sqllogictestBrowserModuleScript() {
+  return `
+      import * as duckdb from "/duckdb/duckdb-browser.mjs";
+
+      function formatCell(value) {
+        if (value === null || value === undefined) {
+          return "NULL";
+        }
+        if (typeof value === "bigint") {
+          return value.toString();
+        }
+        if (typeof value === "boolean") {
+          return value ? "true" : "false";
+        }
+        if (value instanceof Date) {
+          return value.toISOString();
+        }
+        return String(value);
+      }
+
+      function formatRows(result) {
+        const rows = result.toArray();
+        return rows.map((row) => Object.values(row).map(formatCell).join("\\t"));
+      }
+
+      function normalizeError(message) {
+        return String(message || "");
+      }
+
+      async function createSession(config) {
+        const bundles = {
+          mvp: {
+            mainModule: "/duckdb/duckdb-mvp.wasm",
+            mainWorker: "/duckdb/duckdb-browser-mvp.worker.js",
+          },
+          eh: {
+            mainModule: "/duckdb/duckdb-eh.wasm",
+            mainWorker: "/duckdb/duckdb-browser-eh.worker.js",
+          },
+        };
+        const bundle = bundles[config.bundleKey];
+        if (!bundle) {
+          throw new Error("unknown DuckDB-Wasm bundle key: " + config.bundleKey);
+        }
+
+        const logger = new duckdb.ConsoleLogger();
+        const worker = new Worker(bundle.mainWorker);
+        const db = new duckdb.AsyncDuckDB(logger, worker);
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+        await db.open({ allowUnsignedExtensions: true });
+        const conn = await db.connect();
+        return { db, conn, worker };
+      }
+
+      async function requireExtension(conn, extensionRepository, extensionName) {
+        if (extensionName !== "pbi_scanner") {
+          throw new Error("unsupported require extension: " + extensionName);
+        }
+        await conn.query("SET custom_extension_repository='" + extensionRepository + "'");
+        await conn.query("INSTALL pbi_scanner");
+        await conn.query("LOAD pbi_scanner");
+      }
+
+      async function runRecord(session, record, config) {
+        if (record.type === "require") {
+          await requireExtension(session.conn, config.extensionRepository, record.extension);
+          return { status: "pass" };
+        }
+
+        if (record.type === "query") {
+          const result = await session.conn.query(record.sql);
+          const actual = formatRows(result);
+          if (actual.length !== record.expected.length) {
+            return {
+              status: "fail",
+              message:
+                "row count mismatch: expected " +
+                record.expected.length +
+                " got " +
+                actual.length +
+                " (" +
+                JSON.stringify(actual) +
+                ")",
+            };
+          }
+          for (let i = 0; i < record.expected.length; i++) {
+            if (actual[i] !== record.expected[i]) {
+              return {
+                status: "fail",
+                message:
+                  "row " +
+                  (i + 1) +
+                  " mismatch: expected " +
+                  JSON.stringify(record.expected[i]) +
+                  " got " +
+                  JSON.stringify(actual[i]),
+              };
+            }
+          }
+          return { status: "pass" };
+        }
+
+        if (record.type === "statement") {
+          if (record.mode === "ok") {
+            await session.conn.query(record.sql);
+            return { status: "pass" };
+          }
+          if (record.mode === "error") {
+            if (config.skipStatementErrors) {
+              return { status: "skip", message: "statement error checks skipped for wasm_mvp" };
+            }
+            try {
+              await session.conn.query(record.sql);
+              return { status: "fail", message: "expected statement error but query succeeded" };
+            } catch (error) {
+              const message = normalizeError(error && error.message ? error.message : error);
+              const expected = (record.expectedError || []).join("\\n");
+              if (!message.includes(expected)) {
+                return {
+                  status: "fail",
+                  message:
+                    "unexpected error message: expected substring " +
+                    JSON.stringify(expected) +
+                    " in " +
+                    JSON.stringify(message),
+                };
+              }
+              return { status: "pass" };
+            }
+          }
+          return { status: "skip", message: "unsupported statement mode " + record.mode };
+        }
+
+        return { status: "skip", message: "unsupported record type " + record.type };
+      }
+
+      window.runSqllogictestFile = async (config) => {
+        const session = await createSession(config);
+        const results = [];
+        try {
+          for (let i = 0; i < config.records.length; i++) {
+            const record = config.records[i];
+            try {
+              const outcome = await runRecord(session, record, config);
+              results.push({ index: i, record, ...outcome });
+            } catch (error) {
+              results.push({
+                index: i,
+                record,
+                status: "fail",
+                message: normalizeError(error && error.message ? error.message : error),
+              });
+            }
+          }
+        } finally {
+          await session.conn.close();
+          await session.db.terminate();
+          session.worker.terminate();
+        }
+        return results;
+      };
+`;
+}

--- a/test/wasm/sqllogictest_parser.mjs
+++ b/test/wasm/sqllogictest_parser.mjs
@@ -1,0 +1,132 @@
+const DIRECTIVE_RE = /^(query|statement|require)\b/;
+
+function isDirectiveLine(line) {
+  const trimmed = line.trim();
+  return trimmed.startsWith("#") || DIRECTIVE_RE.test(trimmed);
+}
+
+function readUntilSeparator(lines, startIndex) {
+  const blockLines = [];
+  let index = startIndex;
+  while (index < lines.length && lines[index].trim() !== "----") {
+    blockLines.push(lines[index]);
+    index++;
+  }
+  if (index < lines.length && lines[index].trim() === "----") {
+    return { text: blockLines.join("\n").trim(), nextIndex: index + 1, hadSeparator: true };
+  }
+  return { text: blockLines.join("\n").trim(), nextIndex: index, hadSeparator: false };
+}
+
+function readSqlUntilDirective(lines, startIndex) {
+  const sqlLines = [];
+  let index = startIndex;
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!line.trim()) {
+      return { sql: sqlLines.join("\n").trim(), nextIndex: index + 1 };
+    }
+    if (isDirectiveLine(line)) {
+      return { sql: sqlLines.join("\n").trim(), nextIndex: index };
+    }
+    sqlLines.push(line);
+    index++;
+  }
+  return { sql: sqlLines.join("\n").trim(), nextIndex: index };
+}
+
+function readExpectedBlock(lines, startIndex) {
+  const expected = [];
+  let index = startIndex;
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!line.trim()) {
+      return { expected, nextIndex: index + 1 };
+    }
+    if (isDirectiveLine(line)) {
+      return { expected, nextIndex: index };
+    }
+    expected.push(line);
+    index++;
+  }
+  return { expected, nextIndex: index };
+}
+
+export function parseSqllogictest(content, fileName = "unknown.test") {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  const records = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index].trim();
+    index++;
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    if (line.startsWith("require ")) {
+      records.push({
+        type: "require",
+        extension: line.slice("require ".length).trim(),
+        line: index - 1,
+      });
+      continue;
+    }
+
+    if (line.startsWith("query ")) {
+      const remainder = line.slice("query ".length).trim();
+      const types = remainder.split(/\s+/)[0];
+      const { text: sql, nextIndex: sqlEnd, hadSeparator } = readUntilSeparator(lines, index);
+      if (!hadSeparator) {
+        throw new Error(`${fileName}:${index}: expected ---- separator after query`);
+      }
+      index = sqlEnd;
+      const { expected, nextIndex: expectedEnd } = readExpectedBlock(lines, index);
+      index = expectedEnd;
+      records.push({
+        type: "query",
+        types,
+        sql,
+        expected,
+        line: index,
+      });
+      continue;
+    }
+
+    if (line.startsWith("statement ")) {
+      const mode = line.slice("statement ".length).trim();
+      if (!["ok", "error", "maybe"].includes(mode)) {
+        throw new Error(`${fileName}:${index - 1}: unsupported statement mode "${mode}"`);
+      }
+      let sql;
+      let expectedError = [];
+      if (mode === "ok") {
+        const parsedSql = readSqlUntilDirective(lines, index);
+        sql = parsedSql.sql;
+        index = parsedSql.nextIndex;
+      } else {
+        const { text, nextIndex: sqlEnd, hadSeparator } = readUntilSeparator(lines, index);
+        if (!hadSeparator) {
+          throw new Error(`${fileName}:${index}: expected ---- separator after statement ${mode}`);
+        }
+        sql = text;
+        index = sqlEnd;
+        const { expected, nextIndex: expectedEnd } = readExpectedBlock(lines, index);
+        index = expectedEnd;
+        expectedError = expected;
+      }
+      records.push({
+        type: "statement",
+        mode,
+        sql,
+        expectedError,
+        line: index,
+      });
+      continue;
+    }
+
+    throw new Error(`${fileName}:${index - 1}: unsupported sqllogictest directive "${line}"`);
+  }
+
+  return { fileName, records };
+}

--- a/wasm_sql/pbi_scanner_wasm.test
+++ b/wasm_sql/pbi_scanner_wasm.test
@@ -1,6 +1,6 @@
-# name: test/sql/pbi_scanner_wasm.test
+# name: wasm_sql/pbi_scanner_wasm.test
 # description: pbi_scanner validation for DuckDB-Wasm
-# group: [sql]
+# group: [wasm_sql]
 
 # Native offline assertions live in test/sql/pbi_scanner.test.
 # This file holds WASM-specific expectations (direct XMLA URLs, powerbi:// bind


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements phases 1–3 of WASM functional testing (inspired by [Compiling Isn't Running](https://rusty.today/blog/testing-duckdb-wasm-extensions/)) plus approved documentation updates.

### Code
- Browser sqllogictest harness (`run_sqllogictest.mjs`, parser, shared `browser_harness.mjs`)
- `test/sql/pbi_scanner_wasm.test` — WASM-specific offline assertions
- CI: smoke + sqllogictest in `wasm-smoke.yml`
- `make test-pbi-wasm` convenience target

### Docs
- Rewrote `docs/wasm_testing_plan.md` as WASM validation architecture (option A)
- `README.md`, `AGENTS.md`, `docs/wasm.md`, `docs/release_publication.md` updated for dual test files, prerequisites, and release checklist

## Test plan

- [x] `wasm_eh` sqllogictest — 18/18 passed
- [x] `wasm_mvp` sqllogictest — 7 passed, 11 skipped (expected)
- [x] Refactored smoke passes on both platforms
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07999a83-9693-4969-9219-13a167e36d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07999a83-9693-4969-9219-13a167e36d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

